### PR TITLE
DEP: Loosen dependency requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Test
         run: |
           cp $(python -c 'import site; print(site.getsitepackages()[0])')/afqinsight/_version.py afqinsight/_version.py
-          pytest --pyargs afqinsight --cov-report term-missing --cov-config .coveragerc --cov=afqinsight -n auto
+          tox
       - name: Coveralls
         run: |
           coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,44 @@
-.PHONY: clean clean-test clean-pyc clean-build flake lint
+.PHONY: clean clean-test clean-pyc clean-build lint help
+.DEFAULT_GOAL := help
 
-flake:
+lint:         ## Check code style
 	flake8
 	black --check .
 	pydocstyle
 
-lint: flake
-
-test:
-    # Unit testing using pytest
+test:         ## Run unit tests using pytest
 	pytest --pyargs afqinsight --cov-report term-missing --cov-config .coveragerc --cov=afqinsight -n auto
 
-devtest:
+devtest:      ## Run unit tests using pytest and abort testing after first failure
     # Unit testing with the -x option, aborts testing after first failure
     # Useful for development when tests are long
 	pytest -x --pyargs afqinsight --cov-report term-missing --cov-config .coveragerc --cov=afqinsight -n auto
 
-clean: clean-build clean-pyc ## remove all build, test, coverage and Python artifacts
+clean:        ## Remove all build, test, coverage and Python artifacts
+clean: clean-build clean-pyc
 
-clean-build: ## remove build artifacts
+clean-build:  ## Remove build artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -f {} +
 
-clean-pyc: ## remove Python file artifacts
+clean-pyc:    ## Remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
-release: dist ## Package and upload a release
+release:      ## Package and upload a release
+release: dist
 	twine upload dist/*
 
-dist: clean ## Build source and wheel package
+dist:         ## Build source and wheel package
+dist: clean
 	python setup.py sdist
 	python setup.py bdist_wheel --universal
 	ls -l dist
 
+help:         ## Show this help.
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'

--- a/afqinsight/cross_validate.py
+++ b/afqinsight/cross_validate.py
@@ -1,7 +1,6 @@
 """Include functions to validate model performance using cross-validation."""
 
 import copy
-import deepdish.io as ddio
 import hashlib
 import json
 import numpy as np
@@ -15,6 +14,8 @@ from sklearn.model_selection._split import check_cv
 from sklearn.model_selection._validation import _aggregate_score_dicts, _fit_and_score
 from sklearn.pipeline import Pipeline
 from sklearn.utils import indexable
+
+from .h5io import save, load
 
 __all__ = ["cross_validate_checkpoint"]
 
@@ -116,7 +117,7 @@ def _fit_and_score_ckpt(
     pkl_file = os.path.join(workdir, cv_hash + "_estimator.pkl")
 
     if not force_refresh and os.path.exists(h5_file):
-        ckpt_dict = ddio.load(h5_file)
+        ckpt_dict = load(h5_file)
 
         scores = ckpt_dict["scores"]
 
@@ -169,7 +170,7 @@ def _fit_and_score_ckpt(
             "fitted_params": fitted_params,
         }
 
-        ddio.save(h5_file, ckpt_dict)
+        save(h5_file, ckpt_dict)
         return scores
 
 

--- a/afqinsight/h5io.py
+++ b/afqinsight/h5io.py
@@ -1,8 +1,38 @@
 """Recursively save and load dictionaries to hdf5 files.
 
-This module copies extensively from deepdish.io
-with edits to allow more recent versions of dependencies.
-Specifically, we remove the support for pd.Panel.
+This module copies extensively from deepdish.io with edits to allow more
+recent versions of dependencies. Specifically, we remove the support for
+pd.Panel. Below is the entire text of deepdish's BSD-3 license:
+
+---
+
+Copyright (c) 2014, Amit Group
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import numpy as np

--- a/afqinsight/h5io.py
+++ b/afqinsight/h5io.py
@@ -1,0 +1,728 @@
+"""Recursively save and load dictionaries to hdf5 files.
+
+This module copies extensively from deepdish.io
+with edits to allow more recent versions of dependencies.
+Specifically, we remove the support for pd.Panel.
+"""
+
+import numpy as np
+import tables
+import warnings
+from scipy import sparse
+
+try:
+    import pandas as pd
+
+    pd.io.pytables._tables()
+    _pandas = True
+except ImportError:
+    _pandas = False
+
+try:
+    from types import SimpleNamespace
+
+    _sns = True
+except ImportError:
+    _sns = False
+
+
+IO_VERSION = 1
+H5IO_PREFIX = "H5IO"
+H5IO_VERSION_STR = H5IO_PREFIX + "_VERSION"
+H5IO_UNPACK = H5IO_PREFIX + "_H5IO_UNPACK"
+H5IO_ROOT_IS_SNS = H5IO_PREFIX + "_ROOT_IS_SNS"
+
+# Types that should be saved as pytables attribute
+ATTR_TYPES = (
+    int,
+    float,
+    bool,
+    str,
+    bytes,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.bool_,
+    np.complex64,
+    np.complex128,
+)
+
+if _pandas:
+
+    class _HDFStoreWithHandle(pd.io.pytables.HDFStore):
+        def __init__(self, handle):
+            self._path = None
+            self._complevel = None
+            self._complib = None
+            self._fletcher32 = False
+            self._filters = None
+
+            self._handle = handle
+
+
+def is_pandas_dataframe(level):
+    """Check if this level is a pandas dataframe."""
+    return "pandas_version" in level._v_attrs and "pandas_type" in level._v_attrs
+
+
+class ForcePickle(object):
+    """Force objects to be pickled.
+
+    When saving an object with `save`, you can wrap objects in this
+    class to force them to be pickled. They will automatically be unpacked at
+    load time.
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+
+class Compression(object):
+    """Enable explicit compression settings for individual arrays."""
+
+    def __init__(self, obj, compression="default"):
+        self.obj = obj
+        self.compression = compression
+
+
+def _dict_native_ok(d):
+    """Check if a dictionary can be saved natively as HDF5 groups.
+
+    If it can't, it will be pickled.
+    """
+    if len(d) >= 256:
+        return False
+
+    # All keys must be strings
+    for k in d:
+        if not isinstance(k, str):
+            return False
+
+    return True
+
+
+def _get_compression_filters(compression="default"):
+    if compression == "default":
+        compression = "zlib"
+    elif compression is True:
+        compression = "zlib"
+
+    if (
+        compression is False
+        or compression is None
+        or compression == "none"
+        or compression == "None"
+    ):
+        ff = None
+    else:
+        if isinstance(compression, (tuple, list)):
+            compression, level = compression
+        else:
+            level = 9
+
+        try:
+            ff = tables.Filters(complevel=level, complib=compression, shuffle=True)
+        except Exception:
+            warnings.warn(
+                (
+                    "(afqinsight.h5io.save) Missing compression method {}: "
+                    "no compression will be used."
+                ).format(compression)
+            )
+            ff = None
+    return ff
+
+
+def _save_ndarray(handler, group, name, x, filters=None):
+    if np.issubdtype(x.dtype, np.unicode_):
+        # Convert unicode strings to pure byte arrays
+        strtype = b"unicode"
+        itemsize = x.itemsize // 4
+        atom = tables.UInt8Atom()
+        x = x.view(dtype=np.uint8)
+    elif np.issubdtype(x.dtype, np.string_):
+        strtype = b"ascii"
+        itemsize = x.itemsize
+        atom = tables.StringAtom(itemsize)
+    elif x.dtype == np.object:
+        # Not supported by HDF5, force pickling
+        _save_pickled(handler, group, x, name=name)
+        return
+    else:
+        atom = tables.Atom.from_dtype(x.dtype)
+        strtype = None
+        itemsize = None
+
+    if x.ndim > 0 and np.min(x.shape) == 0:
+        sh = np.array(x.shape)
+        atom0 = tables.Atom.from_dtype(np.dtype(np.int64))
+        node = handler.create_array(group, name, atom=atom0, shape=(sh.size,))
+        node._v_attrs.zeroarray_dtype = np.dtype(x.dtype).str.encode("ascii")
+        node[:] = sh
+        return
+
+    if x.ndim == 0 and len(x.shape) == 0:
+        # This is a numpy array scalar. We will store it as a regular scalar
+        # instead, which means it will be unpacked as a numpy scalar (not numpy
+        # array scalar)
+        setattr(group._v_attrs, name, x[()])
+        return
+
+    # For small arrays, compression actually leads to larger files, so we are
+    # settings a threshold here. The threshold has been set through
+    # experimentation.
+    if filters is not None and x.size > 300:
+        node = handler.create_carray(
+            group, name, atom=atom, shape=x.shape, chunkshape=None, filters=filters
+        )
+    else:
+        node = handler.create_array(group, name, atom=atom, shape=x.shape)
+    if strtype is not None:
+        node._v_attrs.strtype = strtype
+        node._v_attrs.itemsize = itemsize
+    node[:] = x
+
+
+def _save_pickled(handler, group, level, name=None):
+    warnings.warn(
+        (
+            "(afqinsight.h5io.save) Pickling {}: This may cause "
+            "incompatibities (for instance between Python 2 and "
+            "3) and should ideally be avoided"
+        ).format(level),
+        DeprecationWarning,
+    )
+    node = handler.create_vlarray(group, name, tables.ObjectAtom())
+    node.append(level)
+
+
+def _is_linkable(level):
+    if isinstance(level, ATTR_TYPES):
+        return False
+    return True
+
+
+def _save_level(handler, group, level, name=None, filters=None, idtable=None):
+    _id = id(level)
+    try:
+        oldpath = idtable[_id]
+    except KeyError:
+        if _is_linkable(level):
+            # store path to object:
+            if group._v_pathname.endswith("/"):
+                idtable[_id] = "{}{}".format(group._v_pathname, name)
+            else:
+                idtable[_id] = "{}/{}".format(group._v_pathname, name)
+    else:
+        # object already saved, so create soft link to it:
+        handler.create_soft_link(group, name, target=oldpath)
+        return
+
+    if isinstance(level, Compression):
+        custom_filters = _get_compression_filters(level.compression)
+        return _save_level(
+            handler,
+            group,
+            level.obj,
+            name=name,
+            filters=custom_filters,
+            idtable=idtable,
+        )
+
+    elif isinstance(level, ForcePickle):
+        _save_pickled(handler, group, level, name=name)
+
+    elif isinstance(level, dict) and _dict_native_ok(level):
+        # First create a new group
+        new_group = handler.create_group(group, name, "dict:{}".format(len(level)))
+        for k, v in level.items():
+            if isinstance(k, str):
+                _save_level(
+                    handler, new_group, v, name=k, filters=filters, idtable=idtable
+                )
+
+    elif (
+        _sns and isinstance(level, SimpleNamespace) and _dict_native_ok(level.__dict__)
+    ):
+        # Create a new group in same manner as for dict
+        new_group = handler.create_group(
+            group, name, "SimpleNamespace:{}".format(len(level.__dict__))
+        )
+        for k, v in level.__dict__.items():
+            if isinstance(k, str):
+                _save_level(
+                    handler, new_group, v, name=k, filters=filters, idtable=idtable
+                )
+
+    elif isinstance(level, list) and len(level) < 256:
+        # Lists can contain other dictionaries and numpy arrays, so we don't
+        # want to serialize them. Instead, we will store each entry as i0, i1,
+        # etc.
+        new_group = handler.create_group(group, name, "list:{}".format(len(level)))
+
+        for i, entry in enumerate(level):
+            level_name = "i{}".format(i)
+            _save_level(
+                handler,
+                new_group,
+                entry,
+                name=level_name,
+                filters=filters,
+                idtable=idtable,
+            )
+
+    elif isinstance(level, tuple) and len(level) < 256:
+        # Lists can contain other dictionaries and numpy arrays, so we don't
+        # want to serialize them. Instead, we will store each entry as i0, i1,
+        # etc.
+        new_group = handler.create_group(group, name, "tuple:{}".format(len(level)))
+
+        for i, entry in enumerate(level):
+            level_name = "i{}".format(i)
+            _save_level(
+                handler,
+                new_group,
+                entry,
+                name=level_name,
+                filters=filters,
+                idtable=idtable,
+            )
+
+    elif isinstance(level, np.ndarray):
+        _save_ndarray(handler, group, name, level, filters=filters)
+
+    elif _pandas and isinstance(level, (pd.DataFrame, pd.Series)):
+        store = _HDFStoreWithHandle(handler)
+        store.put(group._v_pathname + "/" + name, level)
+
+    elif isinstance(level, (sparse.dok_matrix, sparse.lil_matrix)):
+        raise NotImplementedError(
+            "afqinsight.h5io.save does not support DOK or LIL matrices; "
+            "please convert before saving to one of the following supported "
+            "types: BSR, COO, CSR, CSC, DIA"
+        )
+
+    elif isinstance(level, (sparse.csr_matrix, sparse.csc_matrix, sparse.bsr_matrix)):
+        new_group = handler.create_group(group, name, "sparse:")
+
+        _save_ndarray(handler, new_group, "data", level.data, filters=filters)
+        _save_ndarray(handler, new_group, "indices", level.indices, filters=filters)
+        _save_ndarray(handler, new_group, "indptr", level.indptr, filters=filters)
+        _save_ndarray(handler, new_group, "shape", np.asarray(level.shape))
+        new_group._v_attrs.format = level.format
+        new_group._v_attrs.maxprint = level.maxprint
+
+    elif isinstance(level, sparse.dia_matrix):
+        new_group = handler.create_group(group, name, "sparse:")
+
+        _save_ndarray(handler, new_group, "data", level.data, filters=filters)
+        _save_ndarray(handler, new_group, "offsets", level.offsets, filters=filters)
+        _save_ndarray(handler, new_group, "shape", np.asarray(level.shape))
+        new_group._v_attrs.format = level.format
+        new_group._v_attrs.maxprint = level.maxprint
+
+    elif isinstance(level, sparse.coo_matrix):
+        new_group = handler.create_group(group, name, "sparse:")
+
+        _save_ndarray(handler, new_group, "data", level.data, filters=filters)
+        _save_ndarray(handler, new_group, "col", level.col, filters=filters)
+        _save_ndarray(handler, new_group, "row", level.row, filters=filters)
+        _save_ndarray(handler, new_group, "shape", np.asarray(level.shape))
+        new_group._v_attrs.format = level.format
+        new_group._v_attrs.maxprint = level.maxprint
+
+    elif isinstance(level, ATTR_TYPES):
+        setattr(group._v_attrs, name, level)
+
+    elif level is None:
+        # Store a None as an empty group
+        new_group = handler.create_group(group, name, "nonetype:")
+
+    else:
+        _save_pickled(handler, group, level, name=name)
+
+
+def _load_specific_level(handler, grp, path, sel=None, pathtable=None):
+    if path == "":
+        if sel is not None:
+            return _load_sliced_level(handler, grp, sel)
+        else:
+            return _load_level(handler, grp, pathtable)
+    vv = path.split("/", 1)
+    if len(vv) == 1:
+        if hasattr(grp, vv[0]):
+            if sel is not None:
+                return _load_sliced_level(handler, getattr(grp, vv[0]), sel)
+            else:
+                return _load_level(handler, getattr(grp, vv[0]), pathtable)
+        elif hasattr(grp, "_v_attrs") and vv[0] in grp._v_attrs:
+            if sel is not None:
+                raise ValueError("Cannot slice this type")
+            v = grp._v_attrs[vv[0]]
+            if isinstance(v, np.string_):
+                v = v.decode("utf-8")
+            return v
+        else:
+            raise ValueError('Undefined entry "{}"'.format(vv[0]))
+    else:
+        level, rest = vv
+        if level == "":
+            return _load_specific_level(
+                handler, grp.root, rest, sel=sel, pathtable=pathtable
+            )
+        else:
+            if hasattr(grp, level):
+                return _load_specific_level(
+                    handler, getattr(grp, level), rest, sel=sel, pathtable=pathtable
+                )
+            else:
+                raise ValueError('Undefined group "{}"'.format(level))
+
+
+def _load_pickled(level):
+    if isinstance(level[0], ForcePickle):
+        return level[0].obj
+    else:
+        return level[0]
+
+
+def _load_nonlink_level(handler, level, pathtable, pathname):
+    """Load level and builds appropriate type, without handling softlinks."""
+    if isinstance(level, tables.Group):
+        if _sns and (
+            level._v_title.startswith("SimpleNamespace:")
+            or H5IO_ROOT_IS_SNS in level._v_attrs
+        ):
+            val = SimpleNamespace()
+            dct = val.__dict__
+        elif level._v_title.startswith("list:"):
+            dct = {}
+            val = []
+        else:
+            dct = {}
+            val = dct
+        # in case of recursion, object needs to be put in pathtable
+        # before trying to fully load it
+        pathtable[pathname] = val
+
+        # Load sub-groups
+        for grp in level:
+            lev = _load_level(handler, grp, pathtable)
+            n = grp._v_name
+            # Check if it's a complicated pair or a string-value pair
+            if n.startswith("__pair"):
+                dct[lev["key"]] = lev["value"]
+            else:
+                dct[n] = lev
+
+        # Load attributes
+        for name in level._v_attrs._f_list():
+            if name.startswith(H5IO_PREFIX):
+                continue
+            v = level._v_attrs[name]
+            dct[name] = v
+
+        if level._v_title.startswith("list:"):
+            N = int(level._v_title[len("list:") :])
+            for i in range(N):
+                val.append(dct["i{}".format(i)])
+            return val
+        elif level._v_title.startswith("tuple:"):
+            N = int(level._v_title[len("tuple:") :])
+            lst = []
+            for i in range(N):
+                lst.append(dct["i{}".format(i)])
+            return tuple(lst)
+        elif level._v_title.startswith("nonetype:"):
+            return None
+        elif is_pandas_dataframe(level):
+            assert _pandas, "pandas is required to read this file"
+            store = _HDFStoreWithHandle(handler)
+            return store.get(level._v_pathname)
+        elif level._v_title.startswith("sparse:"):
+            frm = level._v_attrs.format
+            if frm in ("csr", "csc", "bsr"):
+                shape = tuple(level.shape[:])
+                cls = {
+                    "csr": sparse.csr_matrix,
+                    "csc": sparse.csc_matrix,
+                    "bsr": sparse.bsr_matrix,
+                }
+                matrix = cls[frm](shape)
+                matrix.data = level.data[:]
+                matrix.indices = level.indices[:]
+                matrix.indptr = level.indptr[:]
+                matrix.maxprint = level._v_attrs.maxprint
+                return matrix
+            elif frm == "dia":
+                shape = tuple(level.shape[:])
+                matrix = sparse.dia_matrix(shape)
+                matrix.data = level.data[:]
+                matrix.offsets = level.offsets[:]
+                matrix.maxprint = level._v_attrs.maxprint
+                return matrix
+            elif frm == "coo":
+                shape = tuple(level.shape[:])
+                matrix = sparse.coo_matrix(shape)
+                matrix.data = level.data[:]
+                matrix.col = level.col[:]
+                matrix.row = level.row[:]
+                matrix.maxprint = level._v_attrs.maxprint
+                return matrix
+            else:
+                raise ValueError("Unknown sparse matrix type: {}".format(frm))
+        else:
+            return val
+
+    elif isinstance(level, tables.VLArray):
+        if level.shape == (1,):
+            return _load_pickled(level)
+        else:
+            return level[:]
+
+    elif isinstance(level, tables.Array):
+        if "zeroarray_dtype" in level._v_attrs:
+            # Unpack zero-size arrays (shape is stored in an HDF5 array and
+            # type is stored in the attibute 'zeroarray_dtype')
+            dtype = level._v_attrs.zeroarray_dtype
+            sh = level[:]
+            return np.zeros(tuple(sh), dtype=dtype)
+
+        if "strtype" in level._v_attrs:
+            strtype = level._v_attrs.strtype
+            itemsize = level._v_attrs.itemsize
+            if strtype == b"unicode":
+                return level[:].view(dtype=(np.unicode_, itemsize))
+            elif strtype == b"ascii":
+                return level[:].view(dtype=(np.string_, itemsize))
+        # This serves two purposes:
+        # (1) unpack big integers: the only time we save arrays like this
+        # (2) unpack non-h5io "scalars"
+        if level.shape == ():
+            return level[()]
+
+        return level[:]
+
+
+def _load_level(handler, level, pathtable):
+    """Load level and builds appropriate type, handling softlinks if necessary."""
+    if isinstance(level, tables.link.SoftLink):
+        # this is a link, so see if target is already loaded, return it
+        pathname = level.target
+        node = level()
+    else:
+        # not a link, but it might be a target that's already been
+        # loaded ... if so, return it
+        pathname = level._v_pathname
+        node = level
+    try:
+        return pathtable[pathname]
+    except KeyError:
+        pathtable[pathname] = _load_nonlink_level(handler, node, pathtable, pathname)
+        return pathtable[pathname]
+
+
+def _load_sliced_level(handler, level, sel):
+    if isinstance(level, tables.link.SoftLink):
+        # this is a link; get target:
+        level = level()
+
+    if isinstance(level, tables.VLArray):
+        if level.shape == (1,):
+            return _load_pickled(level)
+        else:
+            return level[sel]
+
+    elif isinstance(level, tables.Array):
+        return level[sel]
+
+    else:
+        raise ValueError("Cannot partially load this data type using `sel`")
+
+
+def save(path, data, compression="zlib"):
+    """Save any Python structure to an HDF5 file.
+
+    It is particularly suited for Numpy arrays. This function works similar
+    to ``numpy.save``, except if you save a Python object at the top level,
+    you do not need to issue ``data.flat[0]`` to retrieve it from inside a
+    Numpy array of type ``object``.
+
+    Some types of objects get saved natively in HDF5. The rest get serialized
+    automatically.  For most needs, you should be able to stick to the natively
+    supported types, which are:
+
+    * Dictionaries
+    * Short lists and tuples (<256 in length)
+    * Basic data types (including strings and None)
+    * Numpy arrays
+    * Scipy sparse matrices
+    * Pandas ``DataFrame`` and ``Series``
+    * SimpleNamespaces (for Python >= 3.3, but see note below)
+
+    A recommendation is to always convert your data to using only these types
+    That way your data will be portable and can be opened through any HDF5
+    reader.
+
+    Lists and tuples are supported and can contain heterogeneous types. This is
+    mostly useful and plays well with HDF5 for short lists and tuples. If you
+    have a long list (>256) it will be serialized automatically. However,
+    in such cases it is common for the elements to have the same type, in which
+    case we strongly recommend converting to a Numpy array first.
+
+    Note that the SimpleNamespace type will be read in as dictionaries for
+    earlier versions of Python.
+
+    This function requires the `PyTables <http://www.pytables.org/>`_ module to
+    be installed.
+
+    Parameters
+    ----------
+    path : string
+        Filename to which the data is saved.
+
+    data : anything
+        Data to be saved. This can be anything from a Numpy array, a string, an
+        object, or a dictionary containing all of them including more
+        dictionaries.
+
+    compression : string or tuple
+        Set compression method, choosing from `blosc`, `zlib`, `lzo`, `bzip2`
+        and more (see PyTables documentation). It can also be specified as a
+        tuple (e.g. ``('blosc', 5)``), with the latter value specifying the
+        level of compression, choosing from 0 (no compression) to 9 (maximum
+        compression).  Set to `None` to turn off compression. The default is
+        `zlib`, since it is highly portable; for much greater speed, try for
+        instance `blosc`.
+
+    See Also
+    --------
+    load
+    """
+    filters = _get_compression_filters(compression)
+
+    with tables.open_file(path, mode="w") as h5file:
+        # If the data is a dictionary, put it flatly in the root
+        group = h5file.root
+        group._v_attrs[H5IO_VERSION_STR] = IO_VERSION
+        idtable = {}  # dict to keep track of objects already saved
+        # Sparse matrices match isinstance(data, dict), so we'll have to be
+        # more strict with the type checking
+        if isinstance(data, dict) and _dict_native_ok(data):
+            idtable[id(data)] = "/"
+            for key, value in data.items():
+                _save_level(
+                    h5file, group, value, name=key, filters=filters, idtable=idtable
+                )
+
+        elif (
+            _sns
+            and isinstance(data, SimpleNamespace)
+            and _dict_native_ok(data.__dict__)
+        ):
+            idtable[id(data)] = "/"
+            group._v_attrs[H5IO_ROOT_IS_SNS] = True
+            for key, value in data.__dict__.items():
+                _save_level(
+                    h5file, group, value, name=key, filters=filters, idtable=idtable
+                )
+
+        else:
+            _save_level(
+                h5file, group, data, name="data", filters=filters, idtable=idtable
+            )
+            # Mark this to automatically unpack when loaded
+            group._v_attrs[H5IO_UNPACK] = True
+
+
+def load(path, group=None, sel=None, unpack=False):
+    """Load an HDF5 saved with `save`.
+
+    This function requires the `PyTables <http://www.pytables.org/>`_ module to
+    be installed.
+
+    Parameters
+    ----------
+    path : string
+        Filename from which to load the data.
+    group : string or list
+        Load a specific group in the HDF5 hierarchy. If `group` is a list of
+        strings, then a tuple will be returned with all the groups that were
+        specified.
+    sel : slice or tuple of slices
+        If you specify `group` and the target is a numpy array, then you can
+        use this to slice it. This is useful for opening subsets of large HDF5
+        files.
+    unpack : bool
+        If True, a single-entry dictionaries will be unpacked and the value
+        will be returned directly. That is, if you save ``dict(a=100)``, only
+        ``100`` will be loaded.
+
+    Returns
+    -------
+    data : anything
+        Hopefully an identical reconstruction of the data that was saved.
+
+    See Also
+    --------
+    save
+
+    """
+    with tables.open_file(path, mode="r") as h5file:
+        pathtable = {}  # dict to keep track of objects already loaded
+        if group is not None:
+            if isinstance(group, str):
+                data = _load_specific_level(
+                    h5file, h5file, group, sel=sel, pathtable=pathtable
+                )
+            else:  # Assume group is a list or tuple
+                data = []
+                for g in group:
+                    data_i = _load_specific_level(
+                        h5file, h5file, g, sel=sel, pathtable=pathtable
+                    )
+                    data.append(data_i)
+                data = tuple(data)
+        else:
+            grp = h5file.root
+            auto_unpack = H5IO_UNPACK in grp._v_attrs and grp._v_attrs[H5IO_UNPACK]
+            do_unpack = unpack or auto_unpack
+            if do_unpack and len(grp._v_children) == 1:
+                name = next(iter(grp._v_children))
+                data = _load_specific_level(
+                    h5file, grp, name, sel=sel, pathtable=pathtable
+                )
+                do_unpack = False
+            elif sel is not None:
+                raise ValueError(
+                    "Must specify group with `sel` unless it " "automatically unpacks"
+                )
+            else:
+                data = _load_level(h5file, grp, pathtable)
+
+            if H5IO_VERSION_STR in grp._v_attrs:
+                v = grp._v_attrs[H5IO_VERSION_STR]
+            else:
+                v = 0
+
+            if v > IO_VERSION:
+                warnings.warn(
+                    "This file was saved with a newer version of "
+                    "afqinsight.h5io. Please upgrade to make sure it loads "
+                    "correctly."
+                )
+
+            # Attributes can't be unpacked with the method above, so fall back
+            # to this
+            if do_unpack and isinstance(data, dict) and len(data) == 1:
+                data = next(iter(data.values()))
+
+    return data

--- a/afqinsight/tests/test_h5io.py
+++ b/afqinsight/tests/test_h5io.py
@@ -1,0 +1,404 @@
+import numpy as np
+import os
+import pandas as pd
+
+from afqinsight import h5io
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
+try:
+    from types import SimpleNamespace
+
+    _sns = True
+except ImportError:
+    _sns = False
+
+
+@contextmanager
+def tmp_filename():
+    f = NamedTemporaryFile(delete=False)
+    yield f.name
+    f.close()
+    os.unlink(f.name)
+
+
+@contextmanager
+def tmp_file():
+    f = NamedTemporaryFile(delete=False)
+    yield f
+    f.close()
+    os.unlink(f.name)
+
+
+def reconstruct(fn, x):
+    h5io.save(fn, x)
+    return h5io.load(fn)
+
+
+def assert_array(fn, x):
+    h5io.save(fn, x)
+    x1 = h5io.load(fn)
+    np.testing.assert_array_equal(x, x1)
+
+
+def test_basic_data_types():
+    with tmp_filename() as fn:
+        x = 100
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+        x = 1.23
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+        x = "this is a string"
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+        x = b"this is a bytearray"
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+        x = None
+        x1 = reconstruct(fn, x)
+        assert x1 is None
+
+
+def test_big_integers():
+    with tmp_filename() as fn:
+        x = 1239487239847234982392837423874
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+
+def test_numpy_array():
+    with tmp_filename() as fn:
+        x0 = np.arange(3 * 4 * 5, dtype=np.int64).reshape((3, 4, 5))
+        assert_array(fn, x0)
+
+        x0 = x0.astype(np.float32)
+        assert_array(fn, x0)
+
+        x0 = x0.astype(np.uint8)
+        assert_array(fn, x0)
+
+        x0 = x0.astype(np.complex128)
+        x0[0] = 1 + 2j
+        assert_array(fn, x0)
+
+
+def test_numpy_array_zero_size():
+    # Arrays where one of the axes is length 0. These zero-length arrays cannot
+    # be stored natively in HDF5, so we'll have to store only the shape
+    with tmp_filename() as fn:
+        x0 = np.arange(0, dtype=np.int64)
+        assert_array(fn, x0)
+
+        x0 = np.arange(0, dtype=np.float32).reshape((10, 20, 0))
+        assert_array(fn, x0)
+
+        x0 = np.arange(0, dtype=np.complex128).reshape((0, 5, 0))
+        assert_array(fn, x0)
+
+
+def test_numpy_string_array():
+    with tmp_filename() as fn:
+        x0 = np.array([[b"this", b"string"], [b"foo", b"bar"]])
+        assert_array(fn, x0)
+
+        x0 = np.array([["this", "string"], ["foo", "bar"]])
+        assert_array(fn, x0)
+
+
+def test_dictionary():
+    with tmp_filename() as fn:
+        d = dict(
+            a=100,
+            b="this is a string",
+            c=np.ones(5),
+            sub=dict(a=200, b="another string", c=np.random.randn(3, 4)),
+        )
+
+        d1 = reconstruct(fn, d)
+
+        assert d["a"] == d1["a"]
+        assert d["b"] == d1["b"]
+        np.testing.assert_array_equal(d["c"], d1["c"])
+        assert d["sub"]["a"] == d1["sub"]["a"]
+        assert d["sub"]["b"] == d1["sub"]["b"]
+        np.testing.assert_array_equal(d["sub"]["c"], d1["sub"]["c"])
+
+
+def test_simplenamespace():
+    if _sns:
+        with tmp_filename() as fn:
+            d = SimpleNamespace(
+                a=100,
+                b="this is a string",
+                c=np.ones(5),
+                sub=SimpleNamespace(a=200, b="another string", c=np.random.randn(3, 4)),
+            )
+
+            d1 = reconstruct(fn, d)
+
+            assert d.a == d1.a
+            assert d.b == d1.b
+            np.testing.assert_array_equal(d.c, d1.c)
+            assert d.sub.a == d1.sub.a
+            assert d.sub.b == d1.sub.b
+            np.testing.assert_array_equal(d.sub.c, d1.sub.c)
+
+
+def test_softlinks_recursion():
+    with tmp_filename() as fn:
+        A = np.random.randn(3, 3)
+        df = pd.DataFrame({"int": np.arange(3), "name": ["zero", "one", "two"]})
+        AA = 4
+        s = dict(A=A, B=A, c=A, d=A, f=A, g=[A, A, A], AA=AA, h=AA, df=df, df2=df)
+        s["g"].append(s)
+        n = reconstruct(fn, s)
+        assert n["g"][0] is n["A"]
+        assert (
+            n["A"]
+            is n["B"]
+            is n["c"]
+            is n["d"]
+            is n["f"]
+            is n["g"][0]
+            is n["g"][1]
+            is n["g"][2]
+        )
+        assert n["g"][3] is n
+        assert n["AA"] == AA == n["h"]
+        assert n["df"] is n["df2"]
+        assert (n["df"] == df).all().all()
+
+        # test 'sel' option on link ... need to read two vars
+        # to ensure at least one is a link:
+        col1 = h5io.load(fn, "/A", (slice(None), slice(1, 2)))
+        assert np.all(A[:, 1] == col1.flatten())
+        col1 = h5io.load(fn, "/B", (slice(None), slice(1, 2)))
+        assert np.all(A[:, 1] == col1.flatten())
+
+
+def test_softlinks_recursion_sns():
+    if _sns:
+        with tmp_filename() as fn:
+            A = np.random.randn(3, 3)
+            AA = 4
+            s = SimpleNamespace(A=A, B=A, c=A, d=A, f=A, g=[A, A, A], AA=AA, h=AA)
+            s.g.append(s)
+            n = reconstruct(fn, s)
+            assert n.g[0] is n.A
+            assert n.A is n.B is n.c is n.d is n.f is n.g[0] is n.g[1] is n.g[2]
+            assert n.g[3] is n
+            assert n.AA == AA == n.h
+
+
+def test_pickle_recursion():
+    with tmp_filename() as fn:
+        f = {4: 78}
+        f["rec"] = f
+        g = [23.4, f]
+        h = dict(f=f, g=g)
+        h2 = reconstruct(fn, h)
+        assert h2["g"][0] == 23.4
+        assert h2["g"][1] is h2["f"]["rec"] is h2["f"]
+        assert h2["f"][4] == 78
+
+
+def test_list_recursion():
+    with tmp_filename() as fn:
+        lst = [1, 3]
+        inlst = ["inside", "list", lst]
+        inlst.append(inlst)
+        lst.append(lst)
+        lst.append(inlst)
+        lst2 = reconstruct(fn, lst)
+        assert lst2[2] is lst2
+        assert lst2[3][2] is lst2
+        assert lst[3][2] is lst
+        assert lst2[3][3] is lst2[3]
+        assert lst[3][3] is lst[3]
+
+
+def test_list():
+    with tmp_filename() as fn:
+        x = [100, "this is a string", np.ones(3), dict(foo=100)]
+
+        x1 = reconstruct(fn, x)
+
+        assert isinstance(x1, list)
+        assert x[0] == x1[0]
+        assert x[1] == x1[1]
+        np.testing.assert_array_equal(x[2], x1[2])
+        assert x[3]["foo"] == x1[3]["foo"]
+
+
+def test_tuple():
+    with tmp_filename() as fn:
+        x = (100, "this is a string", np.ones(3), dict(foo=100))
+
+        x1 = reconstruct(fn, x)
+
+        assert isinstance(x1, tuple)
+        assert x[0] == x1[0]
+        assert x[1] == x1[1]
+        np.testing.assert_array_equal(x[2], x1[2])
+        assert x[3]["foo"] == x1[3]["foo"]
+
+
+def test_sparse_matrices():
+    import scipy.sparse as S
+
+    with tmp_filename() as fn:
+        x = S.lil_matrix((50, 70))
+        x[34, 37] = 1
+        x[34, 39] = 2.5
+        x[34, 41] = -2
+        x[38, 41] = -1
+
+        x1 = reconstruct(fn, x.tocsr())
+        assert x.shape == x1.shape
+        np.testing.assert_array_equal(x.todense(), x1.todense())
+
+        x1 = reconstruct(fn, x.tocsc())
+        assert x.shape == x1.shape
+        np.testing.assert_array_equal(x.todense(), x1.todense())
+
+        x1 = reconstruct(fn, x.tocoo())
+        assert x.shape == x1.shape
+        np.testing.assert_array_equal(x.todense(), x1.todense())
+
+        x1 = reconstruct(fn, x.todia())
+        assert x.shape == x1.shape
+        np.testing.assert_array_equal(x.todense(), x1.todense())
+
+        x1 = reconstruct(fn, x.tobsr())
+        assert x.shape == x1.shape
+        np.testing.assert_array_equal(x.todense(), x1.todense())
+
+
+def test_array_scalar():
+    with tmp_filename() as fn:
+        v = np.array(12.3)
+        v1 = reconstruct(fn, v)
+        assert v1[()] == v and isinstance(v1[()], np.float64)
+
+        v = np.array(40, dtype=np.int8)
+        v1 = reconstruct(fn, v)
+        assert v1[()] == v and isinstance(v1[()], np.int8)
+
+
+def test_load_group():
+    with tmp_filename() as fn:
+        x = dict(one=np.ones(10), two="string")
+        h5io.save(fn, x)
+
+        one = h5io.load(fn, "/one")
+        np.testing.assert_array_equal(one, x["one"])
+        two = h5io.load(fn, "/two")
+        assert two == x["two"]
+
+        full = h5io.load(fn, "/")
+        np.testing.assert_array_equal(x["one"], full["one"])
+        assert x["two"] == full["two"]
+
+
+def test_load_multiple_groups():
+    with tmp_filename() as fn:
+        x = dict(one=np.ones(10), two="string", three=200)
+        h5io.save(fn, x)
+
+        one, three = h5io.load(fn, ["/one", "/three"])
+        np.testing.assert_array_equal(one, x["one"])
+        assert three == x["three"]
+
+        three, two = h5io.load(fn, ["/three", "/two"])
+        assert three == x["three"]
+        assert two == x["two"]
+
+
+def test_load_slice():
+    with tmp_filename() as fn:
+        x = np.arange(3 * 4 * 5).reshape((3, 4, 5))
+        h5io.save(fn, dict(x=x))
+
+        s = slice(None, 2)
+        xs = h5io.load(fn, "/x", sel=s)
+        np.testing.assert_array_equal(xs, x[s])
+
+        s = (slice(None), slice(1, 3))
+        xs = h5io.load(fn, "/x", sel=s)
+        np.testing.assert_array_equal(xs, x[s])
+
+        xs = h5io.load(fn, sel=s, unpack=True)
+        np.testing.assert_array_equal(xs, x[s])
+
+        h5io.save(fn, x)
+        xs = h5io.load(fn, sel=s)
+        np.testing.assert_array_equal(xs, x[s])
+
+
+def test_force_pickle():
+    with tmp_filename() as fn:
+        x = dict(one=dict(two=np.arange(10)), three="string")
+        xf = dict(one=dict(two=x["one"]["two"]), three=x["three"])
+
+        h5io.save(fn, xf)
+        xs = h5io.load(fn)
+
+        np.testing.assert_array_equal(x["one"]["two"], xs["one"]["two"])
+        assert x["three"] == xs["three"]
+
+        # Try direct loading one
+        two = h5io.load(fn, "/one/two")
+        np.testing.assert_array_equal(x["one"]["two"], two)
+
+
+def test_non_string_key_dict():
+    with tmp_filename() as fn:
+        # These will be pickled, but it should still work
+        x = {0: "zero", 1: "one", 2: "two"}
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+        x = {1 + 1j: "zero", b"test": "one", (1, 2): "two"}
+        x1 = reconstruct(fn, x)
+        assert x == x1
+
+
+def test_force_pickle():
+    with tmp_filename() as fn:
+        x = {0: "zero", 1: "one", 2: "two"}
+        fx = h5io.ForcePickle(x)
+        d = dict(foo=x, bar=100)
+        fd = dict(foo=fx, bar=100)
+        d1 = reconstruct(fn, fd)
+        assert d == d1
+
+
+def test_pandas_dataframe():
+    with tmp_filename() as fn:
+        # These will be pickled, but it should still work
+        df = pd.DataFrame({"int": np.arange(3), "name": ["zero", "one", "two"]})
+        df1 = reconstruct(fn, df)
+        assert (df == df1).all().all()
+
+
+def test_pandas_series():
+    rs = np.random.RandomState(1234)
+    with tmp_filename() as fn:
+        s = pd.Series(rs.randn(5), index=["a", "b", "c", "d", "e"])
+        s1 = reconstruct(fn, s)
+        assert (s == s1).all()
+
+
+def test_compression_true():
+    rs = np.random.RandomState(1234)
+    with tmp_filename() as fn:
+        x = rs.normal(size=(1000, 5))
+        for comp in [None, True, "blosc", "zlib", ("zlib", 5)]:
+            h5io.save(fn, x, compression=comp)
+            x1 = h5io.load(fn)
+            assert (x == x1).all()

--- a/afqinsight/tests/test_h5io.py
+++ b/afqinsight/tests/test_h5io.py
@@ -340,7 +340,7 @@ def test_load_slice():
         np.testing.assert_array_equal(xs, x[s])
 
 
-def test_force_pickle():
+def test_force_pickle1():
     with tmp_filename() as fn:
         x = dict(one=dict(two=np.arange(10)), three="string")
         xf = dict(one=dict(two=x["one"]["two"]), three=x["three"])
@@ -368,7 +368,7 @@ def test_non_string_key_dict():
         assert x == x1
 
 
-def test_force_pickle():
+def test_force_pickle2():
     with tmp_filename() as fn:
         x = {0: "zero", 1: "one", 2: "two"}
         fx = h5io.ForcePickle(x)

--- a/afqinsight/tests/test_h5io.py
+++ b/afqinsight/tests/test_h5io.py
@@ -1,3 +1,40 @@
+"""Test functions in the h5io module
+
+These tests copy extensively from deepdish.io to test the io functions that
+were modified from the same library. Below is the entire text of deepdish's
+BSD-3 license:
+
+---
+
+Copyright (c) 2014, Amit Group
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
 import numpy as np
 import os
 import pandas as pd

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,37 +32,33 @@ setup_requires =
     setuptools_scm
 python_requires = >=3.6
 install_requires =
-    bokeh==1.1.0
-    deepdish==0.3.6
-    groupyr==0.1.10
-    ipywidgets==7.5.1
-    matplotlib==3.3.0
-    numpy==1.19.1
-    palettable==3.1.1
-    pandas==1.1.3
-    scikit-learn==0.23.2
-    scipy==1.5.2
-    sklearn_pandas==2.0.2
-    tables==3.6.1
-    tqdm==4.48.2
-
+    groupyr==0.2.1
+    numpy
+    pandas>=1.1.0
+    scikit-learn>=0.23.1,<0.24
+    sklearn_pandas>=2.0.0
+    tables>=3.0.0
 zip_safe = False
 include_package_data = True
 packages = find:
 
 [options.extras_require]
 dev =
-    black==20.8b1
-    flake8==3.8.3
-    numpydoc==1.1.0
-    pre-commit==2.7.1
-    pydocstyle==5.1.1
-    pytest-cov==2.10.1
-    pytest-xdist[psutil]==2.1.0
-    pytest==6.0.1
-    sphinx==3.2.1
-    sphinx-gallery==0.8.1
-    sphinx-rtd-theme==0.5.0
+    black>=20.8b1
+    flake8>=3.8.3
+    numpydoc>=1.1.0
+    matplotlib>=3.3.0
+    pre-commit>=2.7.1
+    pydocstyle>=5.1.1
+    pytest-cov>=2.10.1
+    pytest-xdist[psutil]>=2.1.0
+    pytest>=6.0.1
+    scipy>=1.2.0,<1.6.0
+    sphinx>=3.2.1
+    sphinx-gallery>=0.8.1
+    sphinx-panels>=0.5.2
+    sphinx-rtd-theme>=0.5.0
+    tox>=1.8.0
 maint =
     rapidfuzz==0.12.2
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+minversion = 1.8.0
+envlist = sklearn{231,232}
+isolated_build = True
+
+[testenv]
+deps =
+    setuptools_scm
+    pytest-cov>=2.10.1
+    pytest-xdist[psutil]==2.1.0
+    pytest>=6.0.1
+    groupyr==0.2.1
+    h5py>=3.0.0
+    numpy
+    pandas>=1.1.0
+    scipy>=1.2.0,<1.6.0
+    sklearn_pandas>=2.0.0
+    tables>=3.0.0
+    sklearn231: scikit-learn==0.23.1
+    sklearn232: scikit-learn==0.23.2
+commands = pytest --pyargs afqinsight --cov-report term-missing --cov-config .coveragerc --cov=afqinsight -n auto


### PR DESCRIPTION
Following the same process as in this [groupyr PR](https://github.com/richford/groupyr/pull/46), this PR tidies up the dependency requirements. It removes unnecessary dependencies and widens the range for others. It also removes the deepdish dependency (it appears my beloved deepdish is no longer maintained and is not compatible with recent pandas versions) by copying the relevant parts into the new h5io module.

The same narrow restrictions on sklearn version mentioned in the groupyr PR above also apply here.