### PR TITLE
ENH: Add unsupervised boolean parameter to load_afq_data

### DIFF
--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -54,12 +54,12 @@ def load_afq_data(
 
     unsupervised : bool, default=False
         If True, do not load target data from the ``fn_subjects`` file.
-    
+
     concat_subject_session : bool, default=False
         If True, create new subject IDs by concatenating the existing subject
         IDs with the session IDs. This is useful when subjects have multiple
         sessions and you with to disambiguate between them.
-    
+
     return_sessions : bool, default=False
         If True, return sessionID
 
@@ -82,7 +82,7 @@ def load_afq_data(
 
     subjects : list
         Subject IDs
-    
+
     sessions : list
         Session IDs. Returned only if ``return_sessions`` is True.
 

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -10,6 +10,40 @@ data_path = op.join(afqi.__path__[0], "data")
 test_data_path = op.join(data_path, "test_data")
 
 
+def test_load_afq_data_smoke():
+    output = load_afq_data(
+        workdir=test_data_path,
+        target_cols=["test_class"],
+        label_encode_cols=["test_class"],
+    )
+    assert len(output) == 7  # nosec
+
+    output = load_afq_data(
+        workdir=test_data_path,
+        target_cols=["test_class"],
+        label_encode_cols=["test_class"],
+        return_sessions=True,
+    )
+    assert len(output) == 8  # nosec
+
+    output = load_afq_data(
+        workdir=test_data_path,
+        target_cols=["test_class"],
+        label_encode_cols=["test_class"],
+        unsupervised=True,
+    )
+    assert len(output) == 5  # nosec
+
+    output = load_afq_data(
+        workdir=test_data_path,
+        target_cols=["test_class"],
+        label_encode_cols=["test_class"],
+        unsupervised=True,
+        return_sessions=True,
+    )
+    assert len(output) == 6  # nosec
+
+
 def test_load_afq_data():
     X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
         workdir=test_data_path,


### PR DESCRIPTION
This PR adds an `unsupervised` boolean parameter to `load_afq_data`, allowing the user to skip the loading of the target `y` csv file.

Resolves #70 