### PR TITLE
Adds error handling for cases where users forget to set target_cols.

### DIFF
--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -139,11 +139,13 @@ def load_afq_data(
             output = X, groups, feature_names, group_names, subjects
     else:
         if target_cols is None:
-            raise ValueError("If you are loading data for a supervised "
-                             "learning problem you must specify the "
-                             "`target_cols` input. If you intended to "
-                             "load data for an unsupervised learning "
-                             "problem, please set `unsupervised=True`")
+            raise ValueError(
+                "If you are loading data for a supervised "
+                "learning problem you must specify the "
+                "`target_cols` input. If you intended to "
+                "load data for an unsupervised learning "
+                "problem, please set `unsupervised=True`."
+            )
         # Read using sep=None, engine="python" to allow for both csv and tsv
         targets = pd.read_csv(
             fn_subjects, sep=None, engine="python", index_col=index_col

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -138,6 +138,12 @@ def load_afq_data(
         else:
             output = X, groups, feature_names, group_names, subjects
     else:
+        if target_cols is None:
+            raise ValueError("If you are loading data for a supervised "
+                             "learning problem you must specify the "
+                             "`target_cols` input. If you intended to "
+                             "load data for an unsupervised learning "
+                             "problem, please set `unsupervised=True`")
         # Read using sep=None, engine="python" to allow for both csv and tsv
         targets = pd.read_csv(
             fn_subjects, sep=None, engine="python", index_col=index_col

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -74,3 +74,7 @@ def test_load_afq_data():
             target_cols=["test_class"],
             label_encode_cols=["test_class", "error"],
         )
+    with pytest.raises(ValueError) as ee:
+        load_afq_data(test_data_path)
+
+    assert "please set `unsupervised=True`" in str(ee.value)


### PR DESCRIPTION
Otherwise, folks will run (as I have...) into a cryptic looking `UnboundLocalError: local variable 'y' referenced before assignment` [here](https://github.com/richford/AFQ-Insight/blob/main/afqinsight/datasets.py#L173)
