### PR TITLE
DOC: Make examples a bit more explicit

### DIFF
--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -14,7 +14,7 @@ from sklearn.preprocessing import LabelEncoder
 from .transform import AFQDataFrameMapper
 
 __all__ = ["load_afq_data", "output_beta_to_afq"]
-DATA_DIR = op.join(op.expanduser("~"), ".afq-insight")
+DATA_DIR = op.join(op.expanduser("~"), ".cache", ".afq-insight")
 
 
 def load_afq_data(
@@ -430,25 +430,7 @@ def fetch_sarica(data_home=None):
     """
     data_home = data_home if data_home is not None else DATA_DIR
     _download_afq_dataset("sarica", data_home=data_home)
-    X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
-        workdir=op.join(data_home, "sarica_data"),
-        dwi_metrics=["md", "fa"],
-        target_cols=["class"],
-        label_encode_cols=["class"],
-    )
-
-    gr = GroupRemover(
-        select=["Right Cingulum Hippocampus", "Left Cingulum Hippocampus"],
-        groups=groups,
-        group_names=group_names,
-    )
-    X = gr.fit_transform(X)
-
-    groups = groups[:36]
-    group_names = [grp for grp in group_names if "Cingulum Hippocampus" not in grp[1]]
-    feature_names = [fn for fn in feature_names if "Cingulum Hippocampus" not in fn[1]]
-
-    return X, y, groups, feature_names, group_names, subjects, classes
+    return op.join(data_home, "sarica_data")
 
 
 def fetch_weston_havens(data_home=None):
@@ -489,21 +471,4 @@ def fetch_weston_havens(data_home=None):
     """
     data_home = data_home if data_home is not None else DATA_DIR
     _download_afq_dataset("weston_havens", data_home=data_home)
-    X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
-        workdir=op.join(data_home, "weston_havens_data"),
-        dwi_metrics=["md", "fa"],
-        target_cols=["Age"],
-    )
-
-    gr = GroupRemover(
-        select=["Right Cingulum Hippocampus", "Left Cingulum Hippocampus"],
-        groups=groups,
-        group_names=group_names,
-    )
-    X = gr.fit_transform(X)
-
-    groups = groups[:36]
-    group_names = [grp for grp in group_names if "Cingulum Hippocampus" not in grp[1]]
-    feature_names = [fn for fn in feature_names if "Cingulum Hippocampus" not in fn[1]]
-
-    return X, y, groups, feature_names, group_names, subjects
+    return op.join(data_home, "weston_havens_data")

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -14,7 +14,7 @@ from sklearn.preprocessing import LabelEncoder
 from .transform import AFQDataFrameMapper
 
 __all__ = ["load_afq_data", "output_beta_to_afq"]
-DATA_DIR = op.join(op.expanduser("~"), ".cache", ".afq-insight")
+DATA_DIR = op.join(op.expanduser("~"), ".cache", "afq-insight")
 
 
 def load_afq_data(

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -388,7 +388,7 @@ def _download_afq_dataset(dataset, data_home):
         _download_url_to_file(dict_["url"], dict_["file"])
 
 
-def fetch_sarica(data_home=None):
+def download_sarica(data_home=None):
     """Fetch the ALS classification dataset from Sarica et al [1]_.
 
     Parameters
@@ -432,7 +432,7 @@ def fetch_sarica(data_home=None):
     return op.join(data_home, "sarica_data")
 
 
-def fetch_weston_havens(data_home=None):
+def download_weston_havens(data_home=None):
     """Load the age prediction dataset from Weston-Havens [1]_.
 
     Parameters

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -6,7 +6,6 @@ import os.path as op
 import pandas as pd
 import requests
 
-from groupyr.transform import GroupRemover
 from collections import namedtuple
 from shutil import copyfile
 from sklearn.preprocessing import LabelEncoder

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -12,22 +12,35 @@ test_data_path = op.join(data_path, "test_data")
 
 
 def test_fetch():
-    X, y, groups, feature_names, group_names, subjects, _ = fetch_sarica()
-    assert X.shape == (48, 3600)
+    sarica_dir = fetch_sarica()
+    X, y, groups, feature_names, group_names, subjects, _ = load_afq_data(
+        workdir=sarica_dir,
+        dwi_metrics=["md", "fa"],
+        target_cols=["class"],
+        label_encode_cols=["class"],
+    )
+
+    assert X.shape == (48, 4000)
     assert y.shape == (48,)
-    assert len(groups) == 36
-    assert len(feature_names) == 3600
-    assert len(group_names) == 36
+    assert len(groups) == 40
+    assert len(feature_names) == 4000
+    assert len(group_names) == 40
     assert len(subjects) == 48
     assert op.isfile(op.join(afqi.datasets.DATA_DIR, "sarica_data", "nodes.csv"))
     assert op.isfile(op.join(afqi.datasets.DATA_DIR, "sarica_data", "subjects.csv"))
 
-    X, y, groups, feature_names, group_names, subjects = fetch_weston_havens()
-    assert X.shape == (77, 3600)
+    wh_dir = fetch_weston_havens()
+    X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
+        workdir=wh_dir,
+        dwi_metrics=["md", "fa"],
+        target_cols=["Age"],
+    )
+
+    assert X.shape == (77, 4000)
     assert y.shape == (77,)
-    assert len(groups) == 36
-    assert len(feature_names) == 3600
-    assert len(group_names) == 36
+    assert len(groups) == 40
+    assert len(feature_names) == 4000
+    assert len(group_names) == 40
     assert len(subjects) == 77
     assert op.isfile(op.join(afqi.datasets.DATA_DIR, "weston_havens_data", "nodes.csv"))
     assert op.isfile(

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -5,14 +5,14 @@ import pytest
 import tempfile
 
 import afqinsight as afqi
-from afqinsight.datasets import load_afq_data, fetch_sarica, fetch_weston_havens
+from afqinsight.datasets import load_afq_data, download_sarica, download_weston_havens
 
 data_path = op.join(afqi.__path__[0], "data")
 test_data_path = op.join(data_path, "test_data")
 
 
 def test_fetch():
-    sarica_dir = fetch_sarica()
+    sarica_dir = download_sarica()
     X, y, groups, feature_names, group_names, subjects, _ = load_afq_data(
         workdir=sarica_dir,
         dwi_metrics=["md", "fa"],
@@ -29,7 +29,7 @@ def test_fetch():
     assert op.isfile(op.join(afqi.datasets.DATA_DIR, "sarica_data", "nodes.csv"))
     assert op.isfile(op.join(afqi.datasets.DATA_DIR, "sarica_data", "subjects.csv"))
 
-    wh_dir = fetch_weston_havens()
+    wh_dir = download_weston_havens()
     X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
         workdir=wh_dir,
         dwi_metrics=["md", "fa"],
@@ -48,8 +48,8 @@ def test_fetch():
     )
 
     with tempfile.TemporaryDirectory() as td:
-        _ = fetch_sarica(data_home=td)
-        _ = fetch_weston_havens(data_home=td)
+        _ = download_sarica(data_home=td)
+        _ = download_weston_havens(data_home=td)
         assert op.isfile(op.join(td, "sarica_data", "nodes.csv"))
         assert op.isfile(op.join(td, "sarica_data", "subjects.csv"))
         assert op.isfile(op.join(td, "weston_havens_data", "nodes.csv"))

--- a/examples/plot_age_regression.py
+++ b/examples/plot_age_regression.py
@@ -28,12 +28,18 @@ For more details, please see [2]_.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from afqinsight.datasets import fetch_weston_havens
+from afqinsight.datasets import fetch_weston_havens, load_afq_data
 from afqinsight import make_afq_regressor_pipeline
 
 from sklearn.model_selection import cross_validate
 
-X, y, groups, feature_names, group_names, subjects = fetch_weston_havens()
+workdir = fetch_weston_havens()
+
+X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
+    workdir=workdir,
+    dwi_metrics=["md", "fa"],
+    target_cols=["Age"],
+)
 
 pipe = make_afq_regressor_pipeline(
     imputer_kwargs={"strategy": "median"},  # Use median imputation

--- a/examples/plot_age_regression.py
+++ b/examples/plot_age_regression.py
@@ -3,26 +3,25 @@
 Predict age from white matter features
 ======================================
 
-Predict subject age from white matter features. This example fetches the Weston-Havens
-dataset described in Yeatman et al [1]_. This dataset contains tractometry
-features from 77 subjects ages 6-50. The plots display the absolute value of the
-mean regression coefficients (averaged across cross-validation splits) for the
-mean diffusivity (MD) features.
+Predict subject age from white matter features. This example fetches the
+Weston-Havens dataset described in Yeatman et al [1]_. This dataset contains
+tractometry features from 77 subjects ages 6-50. The plots display the absolute
+value of the mean regression coefficients (averaged across cross-validation
+splits) for the mean diffusivity (MD) features.
 
 Predictive performance for this example is quite poor. In a research setting,
 one might have to ensemble a number of SGL estimators together and conduct a
-more thorough search of the hyperparameter space.
-For more details, please see [2]_.
+more thorough search of the hyperparameter space. For more details, please see
+[2]_.
 
-.. [1]  Jason D. Yeatman, Brian A. Wandell, & Aviv A. Mezer,
-    "Lifespan maturation and degeneration of human brain white matter"
-    Nature Communications, vol. 5:1, pp. 4932, 2014
-    DOI: 10.1038/ncomms5932
+.. [1]  Jason D. Yeatman, Brian A. Wandell, & Aviv A. Mezer, "Lifespan
+    maturation and degeneration of human brain white matter" Nature
+    Communications, vol. 5:1, pp. 4932, 2014 DOI: 10.1038/ncomms5932
 
 .. [2]  Adam Richie-Halford, Jason Yeatman, Noah Simon, and Ariel Rokem
-   "Multidimensional analysis and detection of informative features in human brain white matter"
-   PLOS Computational Biology, 2021
-   DOI: 10.1371/journal.pcbi.1009136
+   "Multidimensional analysis and detection of informative features in human
+   brain white matter" PLOS Computational Biology, 2021 DOI:
+   10.1371/journal.pcbi.1009136
 
 """
 import matplotlib.pyplot as plt
@@ -33,13 +32,39 @@ from afqinsight import make_afq_regressor_pipeline
 
 from sklearn.model_selection import cross_validate
 
+##########################################################################
+# Fetch example data
+# ------------------
+#
+# The :func:`fetch_weston_havens` function download the data used in this
+# example and places it in the `~/.cache/afq-insight/weston_havens` directory.
+# If the directory does not exist, it is created. The data follows the format
+# expected by the :func:`load_afq_data` function: a file called `nodes.csv` that
+# contains AFQ tract profiles and a file called `subjects.csv` that contains
+# information about the subjects. The two files are linked through the
+# `subjectID` column that should exist in both of them. For more information
+# about this format, see also the `AFQ-Browser documentation
+# <https://yeatmanlab.github.io/AFQ-Browser/dataformat.html>`_ (items 2 and 3).
+
 workdir = fetch_weston_havens()
+
+##########################################################################
+# Read in the data
+# ----------------
+# Next, we read in the data. The :func:`load_afq_data` function expects a string
+# input that points to a directory that holds appropriately-shaped data and
+# returns variables that we will use below in our analysis of the data.
 
 X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
     workdir=workdir,
     dwi_metrics=["md", "fa"],
     target_cols=["Age"],
 )
+
+##########################################################################
+# Create an analysis pipeline
+# ---------------------------
+#
 
 pipe = make_afq_regressor_pipeline(
     imputer_kwargs={"strategy": "median"},  # Use median imputation
@@ -56,7 +81,10 @@ pipe = make_afq_regressor_pipeline(
     tol=1e-2,  # Set a lenient convergence tolerance just for this example
 )
 
-# ``pipe`` is a scikit-learn pipeline and can be used in other scikit-learn functions
+# ``pipe`` is a scikit-learn pipeline and can be used in other scikit-learn
+# functions. For example, here we are doing 5-fold cross-validation using scikit
+# learn's :func:`cross_validate` function.
+
 scores = cross_validate(
     pipe, X, y, cv=5, return_train_score=True, return_estimator=True
 )

--- a/examples/plot_age_regression.py
+++ b/examples/plot_age_regression.py
@@ -27,7 +27,7 @@ more thorough search of the hyperparameter space. For more details, please see
 import matplotlib.pyplot as plt
 import numpy as np
 
-from afqinsight.datasets import fetch_weston_havens, load_afq_data
+from afqinsight.datasets import download_weston_havens, load_afq_data
 from afqinsight import make_afq_regressor_pipeline
 
 from sklearn.model_selection import cross_validate
@@ -36,7 +36,7 @@ from sklearn.model_selection import cross_validate
 # Fetch example data
 # ------------------
 #
-# The :func:`fetch_weston_havens` function download the data used in this
+# The :func:`download_weston_havens` function download the data used in this
 # example and places it in the `~/.cache/afq-insight/weston_havens` directory.
 # If the directory does not exist, it is created. The data follows the format
 # expected by the :func:`load_afq_data` function: a file called `nodes.csv` that
@@ -46,7 +46,7 @@ from sklearn.model_selection import cross_validate
 # about this format, see also the `AFQ-Browser documentation
 # <https://yeatmanlab.github.io/AFQ-Browser/dataformat.html>`_ (items 2 and 3).
 
-workdir = fetch_weston_havens()
+workdir = download_weston_havens()
 
 ##########################################################################
 # Read in the data

--- a/examples/plot_als_classification.py
+++ b/examples/plot_als_classification.py
@@ -28,7 +28,7 @@ For more details on this approach in a research setting, please see [2]_.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from afqinsight.datasets import fetch_sarica
+from afqinsight.datasets import fetch_sarica, load_afq_data
 from afqinsight import make_afq_classifier_pipeline
 
 from groupyr.decomposition import GroupPCA
@@ -36,7 +36,14 @@ from groupyr.decomposition import GroupPCA
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import cross_validate
 
-X, y, groups, feature_names, group_names, subjects, classes = fetch_sarica()
+workdir = fetch_sarica()
+
+X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
+    workdir=workdir,
+    dwi_metrics=["md", "fa"],
+    target_cols=["class"],
+    label_encode_cols=["class"],
+)
 
 # Here we reduce computation time by taking the first 10 principal components of each feature group and performing SGL logistic regression on those components.
 # If you want to train an SGL model without group PCA, set ``do_group_pca = False``. This will increase the number of features by an order of magnitude and slow down execution time.

--- a/examples/plot_als_classification.py
+++ b/examples/plot_als_classification.py
@@ -28,7 +28,7 @@ For more details on this approach in a research setting, please see [2]_.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from afqinsight.datasets import fetch_sarica, load_afq_data
+from afqinsight.datasets import download_sarica, load_afq_data
 from afqinsight import make_afq_classifier_pipeline
 
 from groupyr.decomposition import GroupPCA
@@ -36,7 +36,7 @@ from groupyr.decomposition import GroupPCA
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import cross_validate
 
-workdir = fetch_sarica()
+workdir = download_sarica()
 
 X, y, groups, feature_names, group_names, subjects, classes = load_afq_data(
     workdir=workdir,


### PR DESCRIPTION
The examples as they are now somewhat magically generate the variables that are used for the analysis through the `fetch_*` functions. This PR makes the magic a little bit less magical and a bit more explicit, by showing users where the data ends up and what it looks like when it lands there. This might make it easier for users to adapt the examples to their own use-cases? 