### PR TITLE
Make AFQDataset work with different input formats and make indexable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,7 @@ data
 data_with_weights
 untitled_project
 old_examples
-Untitled.ipynb
+Untitled*.ipynb
 
 # Line contributors file
 line-contributors.txt

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -440,32 +440,32 @@ class AFQDataset:
     y : array-like of shape (n_samples,) or (n_samples, n_targets), optional
         Target values. This will be None if ``unsupervised`` is True
 
-    groups : list of numpy.ndarray
+    groups : list of numpy.ndarray, optional
         The feature indices for each feature group. These are typically used
         to keep group collections of "nodes" into white matter bundles.
 
-    feature_names : list of tuples
+    feature_names : list of tuples, optional
         The multi-indexed columns of X. i.e. the names of the features.
 
-    group_names : list of tuples
+    group_names : list of tuples, optional
         The multi-indexed groups of X. i.e. the names of the feature groups.
 
-    target_cols : list of strings
+    target_cols : list of strings, optional
         List of column names for the target variables in `y`.
 
-    subjects : list
+    subjects : list, optional
         Subject IDs
 
-    sessions : list
+    sessions : list, optional
         Session IDs.
 
-    classes : dict
+    classes : dict, optional
         Class labels for each label encoded column specified in ``y``.
     """
 
     def __init__(
         self,
-        X=None,
+        X,
         y=None,
         groups=None,
         feature_names=None,
@@ -481,6 +481,8 @@ class AFQDataset:
         self.feature_names = feature_names
         self.group_names = group_names
         self.target_cols = target_cols
+        if subjects is None:
+            subjects = [f"sub-{i}" for i in range(len(X))]
         self.subjects = subjects
         self.sessions = sessions
         self.classes = classes
@@ -610,9 +612,7 @@ class AFQDataset:
             feature_names=self.feature_names,
             target_cols=self.target_cols,
             group_names=self.group_names,
-            subjects=np.array(self.subjects)[indices].tolist()
-            if self.subjects is not None
-            else None,
+            subjects=np.array(self.subjects)[indices].tolist(),
             sessions=np.array(self.sessions)[indices].tolist()
             if self.sessions is not None
             else None,

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -589,7 +589,10 @@ class AFQDataset:
         repr_params = [f"n_samples={n_samples}", f"n_features={n_features}"]
 
         if self.y is not None:
-            n_targets = self.y.shape[1] or 1
+            try:
+                n_targets = self.y.shape[1]
+            except IndexError:
+                n_targets = 1
             repr_params += [f"n_targets={n_targets}"]
         if self.target_cols is not None:
             repr_params += [f"targets={self.target_cols}"]

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -610,7 +610,9 @@ class AFQDataset:
             feature_names=self.feature_names,
             target_cols=self.target_cols,
             group_names=self.group_names,
-            subjects=np.array(self.subjects)[indices].tolist(),
+            subjects=np.array(self.subjects)[indices].tolist()
+            if self.subjects is not None
+            else None,
             sessions=np.array(self.sessions)[indices].tolist()
             if self.sessions is not None
             else None,

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -427,6 +427,7 @@ class AFQDataset:
 
     You can drop samples from the dataset that have null target values using the
     `drop_target_na` method.
+    >>> dataset.y = dataset.y.astype(float)
     >>> dataset.y[:5] = np.nan
     >>> dataset.drop_target_na()
     >>> dataset

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -379,11 +379,11 @@ class AFQDataset:
 
     >>> import numpy as np
     >>> AFQDataset(X=np.random.rand(50, 1000), y=np.random.rand(50))
-    AFQDataset(n_samples=50, n_features=1000, targets=None)
+    AFQDataset(n_samples=50, n_features=1000, n_targets=1)
 
     You can keep track of the names of the target variables with the `target_cols` parameter.
     >>> AFQDataset(X=np.random.rand(50, 1000), y=np.random.rand(50), target_cols=["age"])
-    AFQDataset(n_samples=50, n_features=1000, targets=['age'])
+    AFQDataset(n_samples=50, n_features=1000, n_targets=1, targets=['age'])
 
     Source Datasets:
 
@@ -400,12 +400,12 @@ class AFQDataset:
     ...     label_encode_cols=["class"],
     ... )
     >>> dataset
-    AFQDataset(n_samples=48, n_features=4000, targets=['class'])
+    AFQDataset(n_samples=48, n_features=4000, n_targets=1, targets=['class'])
 
     AFQDatasets are indexable and can be sliced.
 
     >>> dataset[0:10]
-    AFQDataset(n_samples=10, n_features=4000, targets=['class'])
+    AFQDataset(n_samples=10, n_features=4000, n_targets=1, targets=['class'])
 
     You can query the length of the dataset as well as the feature and target
     shapes.
@@ -421,16 +421,16 @@ class AFQDataset:
     >>> from sklearn.model_selection import train_test_split
     >>> train_data, test_data = train_test_split(dataset, test_size=0.3, stratify=dataset.y)
     >>> train_data
-    AFQDataset(n_samples=33, n_features=4000, targets=['class'])
+    AFQDataset(n_samples=33, n_features=4000, n_targets=1, targets=['class'])
     >>> test_data
-    AFQDataset(n_samples=15, n_features=4000, targets=['class'])
+    AFQDataset(n_samples=15, n_features=4000, n_targets=1, targets=['class'])
 
     You can drop samples from the dataset that have null target values using the
     `drop_target_na` method.
     >>> dataset.y[:5] = np.nan
     >>> dataset.drop_target_na()
     >>> dataset
-    AFQDataset(n_samples=43, n_features=4000, targets=['class'])
+    AFQDataset(n_samples=43, n_features=4000, n_targets=1, targets=['class'])
 
     Parameters
     ----------
@@ -571,13 +571,9 @@ class AFQDataset:
             enforce_sub_prefix=enforce_sub_prefix,
         )
 
-        y = afq_data.y
-        if afq_data.y is not None:
-            y = afq_data.y.astype(float)
-
         return AFQDataset(
             X=afq_data.X,
-            y=y,
+            y=afq_data.y,
             groups=afq_data.groups,
             feature_names=afq_data.feature_names,
             target_cols=target_cols,
@@ -590,13 +586,15 @@ class AFQDataset:
     def __repr__(self):
         """Return a string representation of the dataset."""
         n_samples, n_features = self.X.shape
-        repr = ", ".join(
-            [
-                f"n_samples={n_samples}",
-                f"n_features={n_features}",
-                f"targets={self.target_cols}",
-            ]
-        )
+        repr_params = [f"n_samples={n_samples}", f"n_features={n_features}"]
+
+        if self.y is not None:
+            n_targets = self.y.shape[1] or 1
+            repr_params += [f"n_targets={n_targets}"]
+        if self.target_cols is not None:
+            repr_params += [f"targets={self.target_cols}"]
+
+        repr = ", ".join(repr_params)
         return f"AFQDataset({repr})"
 
     def __len__(self):

--- a/afqinsight/datasets.py
+++ b/afqinsight/datasets.py
@@ -594,8 +594,7 @@ class AFQDataset:
         if self.target_cols is not None:
             repr_params += [f"targets={self.target_cols}"]
 
-        repr = ", ".join(repr_params)
-        return f"AFQDataset({repr})"
+        return f"AFQDataset({', '.join(repr_params)})"
 
     def __len__(self):
         """Return the number of samples in the dataset."""

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -247,6 +247,7 @@ def test_AFQDataset(target_cols):
     assert np.allclose(tf_dataset[0][0], afq_data.X[0], equal_nan=True)  # nosec
 
     # Test the drop_target_na method
+    afq_data.y = afq_data.y.astype(float)
     if len(target_cols) == 2:
         afq_data.y[0, 0] = np.nan
         y_shape = (47, 2)

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -141,6 +141,29 @@ def test_AFQDataset_shape_len_index():
     assert isinstance(dataset[:2], AFQDataset)
     assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, targets=None)"
 
+    dataset = AFQDataset(X=np.random.rand(10, 4))
+    assert len(dataset) == 10
+    assert dataset.shape == (10, 4)
+    assert len(dataset[:2]) == 2
+    assert isinstance(dataset[:2], AFQDataset)
+    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, targets=None)"
+
+
+def test_drop_target_na():
+    dataset = AFQDataset(X=np.random.rand(10, 4), y=np.random.rand(10))
+    dataset.y[:5] = np.nan
+    dataset.drop_target_na()
+    assert len(dataset) == 5
+
+    dataset = AFQDataset(
+        X=np.random.rand(10, 4),
+        y=np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3]),
+        target_cols=["class"],
+        classes={"class": np.array(["A", "B", "NaN", "C"], dtype=object)},
+    )
+    dataset.drop_target_na()
+    assert len(dataset) == 7
+
 
 @pytest.mark.parametrize("target_cols", [["class"], ["age", "class"]])
 def test_AFQDataset(target_cols):

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -134,19 +134,31 @@ def test_afqdataset_sub_prefix():
 
 
 def test_AFQDataset_shape_len_index():
+    dataset = AFQDataset(
+        X=np.random.rand(10, 4), y=np.random.rand(10), target_cols=["class"]
+    )
+    assert len(dataset) == 10
+    assert dataset.shape == ((10, 4), (10,))
+    assert len(dataset[:2]) == 2
+    assert isinstance(dataset[:2], AFQDataset)
+    assert (
+        repr(dataset)
+        == "AFQDataset(n_samples=10, n_features=4, n_targets=1, targets=['class'])"
+    )
+
     dataset = AFQDataset(X=np.random.rand(10, 4), y=np.random.rand(10))
     assert len(dataset) == 10
     assert dataset.shape == ((10, 4), (10,))
     assert len(dataset[:2]) == 2
     assert isinstance(dataset[:2], AFQDataset)
-    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, targets=None)"
+    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, n_targets=1)"
 
     dataset = AFQDataset(X=np.random.rand(10, 4))
     assert len(dataset) == 10
     assert dataset.shape == (10, 4)
     assert len(dataset[:2]) == 2
     assert isinstance(dataset[:2], AFQDataset)
-    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, targets=None)"
+    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4)"
 
 
 def test_drop_target_na():

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -65,7 +65,7 @@ def test_afqdataset_label_encode():
         subs.to_csv(op.join(temp_dir, "subjects.csv"), index=False)
         nodes.to_csv(op.join(temp_dir, "nodes.csv"), index=False)
 
-        tmp_dataset = afqi.AFQDataset(
+        tmp_dataset = afqi.AFQDataset.from_files(
             fn_nodes=op.join(temp_dir, "nodes.csv"),
             fn_subjects=op.join(temp_dir, "subjects.csv"),
             target_cols=["site"],
@@ -78,7 +78,7 @@ def test_afqdataset_label_encode():
         tmp_dataset.drop_target_na()
         assert tmp_dataset.y.shape == (2,)
 
-        tmp_dataset = afqi.AFQDataset(
+        tmp_dataset = afqi.AFQDataset.from_files(
             fn_nodes=op.join(temp_dir, "nodes.csv"),
             fn_subjects=op.join(temp_dir, "subjects.csv"),
             target_cols=["age", "site"],
@@ -119,7 +119,7 @@ def test_afqdataset_sub_prefix():
         subs.to_csv(op.join(temp_dir, "subjects.csv"), index=False)
         nodes.to_csv(op.join(temp_dir, "nodes.csv"), index=False)
 
-        tmp_dataset = afqi.AFQDataset(
+        tmp_dataset = afqi.AFQDataset.from_files(
             fn_nodes=op.join(temp_dir, "nodes.csv"),
             fn_subjects=op.join(temp_dir, "subjects.csv"),
             target_cols=["age"],
@@ -136,7 +136,7 @@ def test_afqdataset_sub_prefix():
 @pytest.mark.parametrize("target_cols", [["class"], ["age", "class"]])
 def test_AFQDataset(target_cols):
     sarica_dir = download_sarica()
-    afq_data = AFQDataset(
+    afq_data = AFQDataset.from_files(
         fn_nodes=op.join(sarica_dir, "nodes.csv"),
         fn_subjects=op.join(sarica_dir, "subjects.csv"),
         dwi_metrics=["md", "fa"],
@@ -215,7 +215,7 @@ def test_AFQDataset(target_cols):
 
     # Do it all again for an unsupervised dataset
 
-    afq_data = AFQDataset(
+    afq_data = AFQDataset.from_files(
         fn_nodes=op.join(sarica_dir, "nodes.csv"),
         fn_subjects=op.join(sarica_dir, "subjects.csv"),
         dwi_metrics=["md", "fa"],

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -22,20 +22,20 @@ test_data_path = op.join(data_path, "test_data")
 def test_bundles2channels():
     X0 = np.random.rand(50, 4000)
     X1 = bundles2channels(X0, n_nodes=100, n_channels=40, channels_last=True)
-    assert X1.shape == (50, 100, 40)
-    assert np.allclose(X0[:, :100], X1[:, :, 0])
+    assert X1.shape == (50, 100, 40)  # nosec
+    assert np.allclose(X0[:, :100], X1[:, :, 0])  # nosec
 
     X1 = bundles2channels(X0, n_nodes=100, n_channels=40, channels_last=False)
-    assert X1.shape == (50, 40, 100)
-    assert np.allclose(X0[:, :100], X1[:, 0, :])
+    assert X1.shape == (50, 40, 100)  # nosec
+    assert np.allclose(X0[:, :100], X1[:, 0, :])  # nosec
 
     with pytest.raises(ValueError):
         bundles2channels(X0, n_nodes=1000, n_channels=7)
 
 
 def test_standardize_subject_id():
-    assert standardize_subject_id("sub-01") == "sub-01"
-    assert standardize_subject_id("01") == "sub-01"
+    assert standardize_subject_id("sub-01") == "sub-01"  # nosec
+    assert standardize_subject_id("01") == "sub-01"  # nosec
 
 
 def test_afqdataset_label_encode():
@@ -74,9 +74,9 @@ def test_afqdataset_label_encode():
             label_encode_cols=["site"],
         )
 
-        assert tmp_dataset.y.shape == (3,)
+        assert tmp_dataset.y.shape == (3,)  # nosec
         tmp_dataset.drop_target_na()
-        assert tmp_dataset.y.shape == (2,)
+        assert tmp_dataset.y.shape == (2,)  # nosec
 
         tmp_dataset = afqi.AFQDataset.from_files(
             fn_nodes=op.join(temp_dir, "nodes.csv"),
@@ -87,9 +87,9 @@ def test_afqdataset_label_encode():
             label_encode_cols=["site"],
         )
 
-        assert tmp_dataset.y.shape == (3, 2)
+        assert tmp_dataset.y.shape == (3, 2)  # nosec
         tmp_dataset.drop_target_na()
-        assert tmp_dataset.y.shape == (2, 2)
+        assert tmp_dataset.y.shape == (2, 2)  # nosec
 
 
 def test_afqdataset_sub_prefix():
@@ -127,45 +127,47 @@ def test_afqdataset_sub_prefix():
             index_col="subject_id",
         )
 
-    assert set(tmp_dataset.subjects) == set([f"sub-{i}" for i in range(1, 4)])
-    assert tmp_dataset.X.shape == (3, 4)
-    assert tmp_dataset.y.shape == (3,)
-    assert np.isnan(tmp_dataset.y).sum() == 0
+    assert set(tmp_dataset.subjects) == set([f"sub-{i}" for i in range(1, 4)])  # nosec
+    assert tmp_dataset.X.shape == (3, 4)  # nosec
+    assert tmp_dataset.y.shape == (3,)  # nosec
+    assert np.isnan(tmp_dataset.y).sum() == 0  # nosec
 
 
 def test_AFQDataset_shape_len_index():
     dataset = AFQDataset(
         X=np.random.rand(10, 4), y=np.random.rand(10), target_cols=["class"]
     )
-    assert len(dataset) == 10
-    assert dataset.shape == ((10, 4), (10,))
-    assert len(dataset[:2]) == 2
-    assert isinstance(dataset[:2], AFQDataset)
+    assert len(dataset) == 10  # nosec
+    assert dataset.shape == ((10, 4), (10,))  # nosec
+    assert len(dataset[:2]) == 2  # nosec
+    assert isinstance(dataset[:2], AFQDataset)  # nosec
     assert (
         repr(dataset)
         == "AFQDataset(n_samples=10, n_features=4, n_targets=1, targets=['class'])"
-    )
+    )  # nosec
 
     dataset = AFQDataset(X=np.random.rand(10, 4), y=np.random.rand(10))
-    assert len(dataset) == 10
-    assert dataset.shape == ((10, 4), (10,))
-    assert len(dataset[:2]) == 2
-    assert isinstance(dataset[:2], AFQDataset)
-    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, n_targets=1)"
+    assert len(dataset) == 10  # nosec
+    assert dataset.shape == ((10, 4), (10,))  # nosec
+    assert len(dataset[:2]) == 2  # nosec
+    assert isinstance(dataset[:2], AFQDataset)  # nosec
+    assert (
+        repr(dataset) == "AFQDataset(n_samples=10, n_features=4, n_targets=1)"
+    )  # nosec
 
     dataset = AFQDataset(X=np.random.rand(10, 4))
-    assert len(dataset) == 10
-    assert dataset.shape == (10, 4)
-    assert len(dataset[:2]) == 2
-    assert isinstance(dataset[:2], AFQDataset)
-    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4)"
+    assert len(dataset) == 10  # nosec
+    assert dataset.shape == (10, 4)  # nosec
+    assert len(dataset[:2]) == 2  # nosec
+    assert isinstance(dataset[:2], AFQDataset)  # nosec
+    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4)"  # nosec
 
 
 def test_drop_target_na():
     dataset = AFQDataset(X=np.random.rand(10, 4), y=np.random.rand(10))
     dataset.y[:5] = np.nan
     dataset.drop_target_na()
-    assert len(dataset) == 5
+    assert len(dataset) == 5  # nosec
 
     dataset = AFQDataset(
         X=np.random.rand(10, 4),
@@ -174,7 +176,7 @@ def test_drop_target_na():
         classes={"class": np.array(["A", "B", "NaN", "C"], dtype=object)},
     )
     dataset.drop_target_na()
-    assert len(dataset) == 7
+    assert len(dataset) == 7  # nosec
 
 
 @pytest.mark.parametrize("target_cols", [["class"], ["age", "class"]])
@@ -201,7 +203,7 @@ def test_AFQDataset(target_cols):
     # Test pytorch dataset method
 
     pt_dataset = afq_data.as_torch_dataset()
-    assert len(pt_dataset) == 48
+    assert len(pt_dataset) == 48  # nosec
     assert pt_dataset.X.shape == (48, 40, 100)  # nosec
     assert pt_dataset.y.shape == y_shape  # nosec
     assert np.allclose(
@@ -209,7 +211,7 @@ def test_AFQDataset(target_cols):
     )  # nosec
 
     pt_dataset = afq_data.as_torch_dataset(channels_last=True)
-    assert len(pt_dataset) == 48
+    assert len(pt_dataset) == 48  # nosec
     assert pt_dataset.X.shape == (48, 100, 40)  # nosec
     assert pt_dataset.y.shape == y_shape  # nosec
     assert np.allclose(
@@ -217,7 +219,7 @@ def test_AFQDataset(target_cols):
     )  # nosec
 
     pt_dataset = afq_data.as_torch_dataset(bundles_as_channels=False)
-    assert len(pt_dataset) == 48
+    assert len(pt_dataset) == 48  # nosec
     assert pt_dataset.X.shape == (48, 4000)  # nosec
     assert pt_dataset.y.shape == y_shape  # nosec
     assert np.allclose(pt_dataset[0][0], afq_data.X[0], equal_nan=True)  # nosec
@@ -225,7 +227,7 @@ def test_AFQDataset(target_cols):
     # Test tensorflow dataset method
 
     tf_dataset = list(afq_data.as_tensorflow_dataset().as_numpy_iterator())
-    assert len(tf_dataset) == 48
+    assert len(tf_dataset) == 48  # nosec
     assert np.allclose(
         tf_dataset[0][0][:, 0], afq_data.X[0, :100], equal_nan=True
     )  # nosec
@@ -233,7 +235,7 @@ def test_AFQDataset(target_cols):
     tf_dataset = list(
         afq_data.as_tensorflow_dataset(channels_last=False).as_numpy_iterator()
     )
-    assert len(tf_dataset) == 48
+    assert len(tf_dataset) == 48  # nosec
     assert np.allclose(
         tf_dataset[0][0][0], afq_data.X[0, :100], equal_nan=True
     )  # nosec
@@ -241,7 +243,7 @@ def test_AFQDataset(target_cols):
     tf_dataset = list(
         afq_data.as_tensorflow_dataset(bundles_as_channels=False).as_numpy_iterator()
     )
-    assert len(tf_dataset) == 48
+    assert len(tf_dataset) == 48  # nosec
     assert np.allclose(tf_dataset[0][0], afq_data.X[0], equal_nan=True)  # nosec
 
     # Test the drop_target_na method
@@ -274,13 +276,13 @@ def test_AFQDataset(target_cols):
     assert len(afq_data.subjects) == 48  # nosec
 
     pt_dataset = afq_data.as_torch_dataset()
-    assert len(pt_dataset) == 48
+    assert len(pt_dataset) == 48  # nosec
     assert pt_dataset.X.shape == (48, 40, 100)  # nosec
     assert torch.all(torch.eq(pt_dataset.y, torch.tensor([])))  # nosec
     assert np.allclose(pt_dataset[0][0], afq_data.X[0, :100], equal_nan=True)  # nosec
 
     tf_dataset = list(afq_data.as_tensorflow_dataset().as_numpy_iterator())
-    assert len(tf_dataset) == 48
+    assert len(tf_dataset) == 48  # nosec
     assert np.allclose(
         tf_dataset[0][:, 0], afq_data.X[0, :100], equal_nan=True
     )  # nosec

--- a/afqinsight/tests/test_datasets.py
+++ b/afqinsight/tests/test_datasets.py
@@ -133,6 +133,15 @@ def test_afqdataset_sub_prefix():
     assert np.isnan(tmp_dataset.y).sum() == 0
 
 
+def test_AFQDataset_shape_len_index():
+    dataset = AFQDataset(X=np.random.rand(10, 4), y=np.random.rand(10))
+    assert len(dataset) == 10
+    assert dataset.shape == ((10, 4), (10,))
+    assert len(dataset[:2]) == 2
+    assert isinstance(dataset[:2], AFQDataset)
+    assert repr(dataset) == "AFQDataset(n_samples=10, n_features=4, targets=None)"
+
+
 @pytest.mark.parametrize("target_cols", [["class"], ["age", "class"]])
 def test_AFQDataset(target_cols):
     sarica_dir = download_sarica()


### PR DESCRIPTION
Resolves #98
This PR
- [x] makes AFQDataset initialization more general so that user can provide X, y, groups, feature_names, group_names, subjects, sessions, classes explicitly on init.
- [x] create a new static method from_files() that takes all of the filenames that are in the current AFQDataset init method and returns an AFQDataset object with all of the data read in.
- [x] Make AFQDataset more array-like by adding `__getitem__` and `__len__` methods and a shape parameter. This means users can do things like `dataset[10:20]` and also that `AFQDataset`s can be used as input to sklearn functions like `train_test_split`.
- [x] Adds a lot of detail and doctests to `AFQDataset`'s docstring

Note that I chose a different solution to dataset splitting than the one I proposed in #98. I think making the datasets indexable and therefore interoperable with scikit-learn's already existing, performant, and robust model selection routines is a much better solution than rolling our own `split` method.

This doesn't resolve the need for imputation methods, which we hint at in #98 but I now think that if we still want those, we should open up another issue and PR for that.