### PR TITLE
ENH: Add parametric.py module, add plot_regresion_profiles to plot.py, and update plot_als_comparison.py example

### DIFF
--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -5,48 +5,45 @@ import statsmodels.formula.api as smf
 
 from sklearn.impute import SimpleImputer
 from statsmodels.api import OLS
-from statsmodels.stats.anova import anova_lm
 from statsmodels.stats.multitest import multipletests
 
-from .datasets import AFQDataset
 
 def node_wise_regression(
-	afq_dataset,
-	tract,
-	metric,
-	formula, 
-	group='group',
-	lme=False,
-	rand_eff='subjectID',
+    afq_dataset,
+    tract,
+    metric,
+    formula,
+    group="group",
+    lme=False,
+    rand_eff="subjectID",
 ):
-    
     """Model group differences using node-wise regression along the length of the tract.
        Returns a list of beta-weights, confidence intervals, p-values, and rejection criteria
-       based on multiple-comparison correction. 
-       
+       based on multiple-comparison correction.
+
        Based on this example: https://github.com/yeatmanlab/AFQ-Insight/blob/main/examples/plot_als_comparison.py
 
     Parameters
     ----------
-    
+
     afq_dataset: AFQDataset
         Loaded AFQDataset object
-        
+
     tract: str
         String specifying the tract to model
-    
+
     metric: str
         String specifying which diffusion metric to use as an outcome
         eg. 'fa'
-        
+
     formula: str
         An R-style formula <https://www.statsmodels.org/dev/example_formulas.html>
         specifying the regression model to fit at each node. This can take the form
         of either a linear mixed-effects model or OLS regression
-        
+
     lme: Bool, default=False
         Boolean specifying whether to fit a linear mixed-effects model
-        
+
     rand_eff: str, default='subjectID'
         String specifying the random effect grouping structure for linear mixed-effects
         models. If using anything other than the default value, this column must be present
@@ -55,28 +52,28 @@ def node_wise_regression(
 
     Returns
     -------
-    
+
     tract_dict: dict
         A dictionary with the following key-value pairs:
-        
+
         {'tract': tract,
-                  'reference_coefs': coefs_default, 
+                  'reference_coefs': coefs_default,
                   'group_coefs': coefs_treat,
                   'reference_CI': cis_default,
                   'group_CI': cis_treat,
                   'pvals': pvals,
                   'reject_idx': reject_idx,
                   'model_fits': fits}
-        
+
         tract: str
             The tract described by this dictionary
-            
+
         reference_coefs: list of floats
-            A list of beta-weights representing the average diffusion metric for the 
+            A list of beta-weights representing the average diffusion metric for the
             reference group on a diffusion metric at a given location along the tract
-            
+
         group_coefs: list of floats
-            A list of beta-weights representing the average group effect metric for the 
+            A list of beta-weights representing the average group effect metric for the
             treatment group on a diffusion metric at a given location along the tract
 
         reference_CI: np.array of np.array
@@ -88,18 +85,18 @@ def node_wise_regression(
             around the estimated beta-weight of the treatment effect at a given location along the tract
 
         pvals: list of floats
-            A list of p-values testing whether or not the beta-weight of the group effect is 
+            A list of p-values testing whether or not the beta-weight of the group effect is
             different from 0
 
         reject_idx: list of Booleans
             A list of node indices where the null hypothesis is rejected after multiple-comparison
             corrections
-            
+
         model_fits: list of statsmodels objects
-            A list of the statsmodels object fit along the length of the nodes 
-        
+            A list of the statsmodels object fit along the length of the nodes
+
     """
-    
+
     X = afq_dataset.X
     y = afq_dataset.y
     groups = afq_dataset.groups
@@ -108,63 +105,71 @@ def node_wise_regression(
     subjects = afq_dataset.subjects
 
     X = SimpleImputer(strategy="median").fit_transform(X)
-    
-    tract_data = pd.DataFrame(columns=afq_dataset.feature_names, data=X).filter(like=tract).filter(like=metric)
-    
+
+    tract_data = (
+        pd.DataFrame(columns=afq_dataset.feature_names, data=X)
+        .filter(like=tract)
+        .filter(like=metric)
+    )
+
     pvals = np.zeros(tract_data.shape[-1])
     coefs_default = np.zeros(tract_data.shape[-1])
     coefs_treat = np.zeros(tract_data.shape[-1])
     cis_default = np.zeros((tract_data.shape[-1], 2))
     cis_treat = np.zeros((tract_data.shape[-1], 2))
     fits = {}
-    
+
     # Loop through each node and fit a model
     for ii, column in enumerate(tract_data.columns):
-    
+
         # fit linear mixed-effects model
         if lme:
 
             this = pd.DataFrame(afq_dataset.y, columns=afq_dataset.target_cols)
             this[metric] = tract_data[column]
-            
+
             # if no random effect specified, use subjectID as random effect
-            if rand_eff == 'subjectID':
-                this['subjectID'] = afq_dataset.subjects
-            
+            if rand_eff == "subjectID":
+                this["subjectID"] = afq_dataset.subjects
+
             model = smf.mixedlm(formula, this, groups=rand_eff)
             fit = model.fit()
             fits[column] = fit
-    
+
         # fit OLS model
         else:
-            
+
             _, _, _ = column
             this = pd.DataFrame(afq_dataset.y, columns=afq_dataset.target_cols)
             this[metric] = tract_data[column]
-                        
+
             model = OLS.from_formula(formula, this)
             fit = model.fit()
             fits[column] = fit
-            
+
         # pull out coefficients, CIs, and p-values from our model
-        coefs_default[ii] = fit.params.filter(regex='Intercept', axis=0)[0]
+        coefs_default[ii] = fit.params.filter(regex="Intercept", axis=0)[0]
         coefs_treat[ii] = fit.params.filter(regex=group, axis=0)[0]
-        
-        cis_default[ii] = fit.conf_int(alpha=0.05).filter(regex='Intercept', axis=0).values
+
+        cis_default[ii] = (
+            fit.conf_int(alpha=0.05).filter(regex="Intercept", axis=0).values
+        )
         cis_treat[ii] = fit.conf_int(alpha=0.05).filter(regex=group, axis=0).values
         pvals[ii] = fit.pvalues.filter(regex=group, axis=0)[0]
-    
+
     # Correct p-values for multiple comparisons
     reject, pval_corrected, _, _ = multipletests(pvals, alpha=0.05, method="fdr_bh")
     reject_idx = np.where(reject)
-    
-    tract_dict = {'tract': tract,
-                  'reference_coefs': coefs_default, 
-                  'group_coefs': coefs_treat,
-                  'reference_CI': cis_default,
-                  'group_CI': cis_treat,
-                  'pvals': pvals,
-                  'reject_idx': reject_idx,
-                  'model_fits': fits}
-    
+
+    tract_dict = {
+        "tract": tract,
+        "reference_coefs": coefs_default,
+        "group_coefs": coefs_treat,
+        "reference_CI": cis_default,
+        "group_CI": cis_treat,
+        "pvals": pvals,
+        "reject_idx": reject_idx,
+        "model_fits": fits,
+    }
+
     return tract_dict

--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -97,7 +97,7 @@ def node_wise_regression(
     """
 
     X = SimpleImputer(strategy="median").fit_transform(afq_dataset.X)
-    afqdata.target_cols[0] = group
+    afq_dataset.target_cols[0] = group
 
     tract_data = (
         pd.DataFrame(columns=afq_dataset.feature_names, data=X)

--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -1,0 +1,170 @@
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import statsmodels.formula.api as smf
+
+from sklearn.impute import SimpleImputer
+from statsmodels.api import OLS
+from statsmodels.stats.anova import anova_lm
+from statsmodels.stats.multitest import multipletests
+
+from .datasets import AFQDataset
+
+def node_wise_regression(
+	afq_dataset,
+	tract,
+	metric,
+	formula, 
+	group='group',
+	lme=False,
+	rand_eff='subjectID',
+):
+    
+    """Model group differences using node-wise regression along the length of the tract.
+       Returns a list of beta-weights, confidence intervals, p-values, and rejection criteria
+       based on multiple-comparison correction. 
+       
+       Based on this example: https://github.com/yeatmanlab/AFQ-Insight/blob/main/examples/plot_als_comparison.py
+
+    Parameters
+    ----------
+    
+    afq_dataset: AFQDataset
+        Loaded AFQDataset object
+        
+    tract: str
+        String specifying the tract to model
+    
+    metric: str
+        String specifying which diffusion metric to use as an outcome
+        eg. 'fa'
+        
+    formula: str
+        An R-style formula <https://www.statsmodels.org/dev/example_formulas.html>
+        specifying the regression model to fit at each node. This can take the form
+        of either a linear mixed-effects model or OLS regression
+        
+    lme: Bool, default=False
+        Boolean specifying whether to fit a linear mixed-effects model
+        
+    rand_eff: str, default='subjectID'
+        String specifying the random effect grouping structure for linear mixed-effects
+        models. If using anything other than the default value, this column must be present
+        in the 'target_cols' of the AFQDataset object
+
+
+    Returns
+    -------
+    
+    tract_dict: dict
+        A dictionary with the following key-value pairs:
+        
+        {'tract': tract,
+                  'reference_coefs': coefs_default, 
+                  'group_coefs': coefs_treat,
+                  'reference_CI': cis_default,
+                  'group_CI': cis_treat,
+                  'pvals': pvals,
+                  'reject_idx': reject_idx,
+                  'model_fits': fits}
+        
+        tract: str
+            The tract described by this dictionary
+            
+        reference_coefs: list of floats
+            A list of beta-weights representing the average diffusion metric for the 
+            reference group on a diffusion metric at a given location along the tract
+            
+        group_coefs: list of floats
+            A list of beta-weights representing the average group effect metric for the 
+            treatment group on a diffusion metric at a given location along the tract
+
+        reference_CI: np.array of np.array
+            A numpy array containing a series of numpy arrays indicating the 95% confidence interval
+            around the estimated beta-weight of the reference category at a given location along the tract
+
+        group_CI: np.array of np.array
+            A numpy array containing a series of numpy arrays indicating the 95% confidence interval
+            around the estimated beta-weight of the treatment effect at a given location along the tract
+
+        pvals: list of floats
+            A list of p-values testing whether or not the beta-weight of the group effect is 
+            different from 0
+
+        reject_idx: list of Booleans
+            A list of node indices where the null hypothesis is rejected after multiple-comparison
+            corrections
+            
+        model_fits: list of statsmodels objects
+            A list of the statsmodels object fit along the length of the nodes 
+        
+    """
+    
+    X = afq_dataset.X
+    y = afq_dataset.y
+    groups = afq_dataset.groups
+    feature_names = afq_dataset.feature_names
+    group_names = afq_dataset.group_names
+    subjects = afq_dataset.subjects
+
+    X = SimpleImputer(strategy="median").fit_transform(X)
+    
+    tract_data = pd.DataFrame(columns=afq_dataset.feature_names, data=X).filter(like=tract).filter(like=metric)
+    
+    pvals = np.zeros(tract_data.shape[-1])
+    coefs_default = np.zeros(tract_data.shape[-1])
+    coefs_treat = np.zeros(tract_data.shape[-1])
+    cis_default = np.zeros((tract_data.shape[-1], 2))
+    cis_treat = np.zeros((tract_data.shape[-1], 2))
+    fits = {}
+    
+    # Loop through each node and fit a model
+    for ii, column in enumerate(tract_data.columns):
+    
+        # fit linear mixed-effects model
+        if lme:
+
+            this = pd.DataFrame(afq_dataset.y, columns=afq_dataset.target_cols)
+            this[metric] = tract_data[column]
+            
+            # if no random effect specified, use subjectID as random effect
+            if rand_eff == 'subjectID':
+                this['subjectID'] = afq_dataset.subjects
+            
+            model = smf.mixedlm(formula, this, groups=rand_eff)
+            fit = model.fit()
+            fits[column] = fit
+    
+        # fit OLS model
+        else:
+            
+            _, _, _ = column
+            this = pd.DataFrame(afq_dataset.y, columns=afq_dataset.target_cols)
+            this[metric] = tract_data[column]
+                        
+            model = OLS.from_formula(formula, this)
+            fit = model.fit()
+            fits[column] = fit
+            
+        # pull out coefficients, CIs, and p-values from our model
+        coefs_default[ii] = fit.params.filter(regex='Intercept', axis=0)[0]
+        coefs_treat[ii] = fit.params.filter(regex=group, axis=0)[0]
+        
+        cis_default[ii] = fit.conf_int(alpha=0.05).filter(regex='Intercept', axis=0).values
+        cis_treat[ii] = fit.conf_int(alpha=0.05).filter(regex=group, axis=0).values
+        pvals[ii] = fit.pvalues.filter(regex=group, axis=0)[0]
+    
+    # Correct p-values for multiple comparisons
+    reject, pval_corrected, _, _ = multipletests(pvals, alpha=0.05, method="fdr_bh")
+    reject_idx = np.where(reject)
+    
+    tract_dict = {'tract': tract,
+                  'reference_coefs': coefs_default, 
+                  'group_coefs': coefs_treat,
+                  'reference_CI': cis_default,
+                  'group_CI': cis_treat,
+                  'pvals': pvals,
+                  'reject_idx': reject_idx,
+                  'model_fits': fits}
+    
+    return tract_dict

--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import seaborn as sns
 import statsmodels.formula.api as smf
 
 from sklearn.impute import SimpleImputer
@@ -97,14 +96,7 @@ def node_wise_regression(
 
     """
 
-    X = afq_dataset.X
-    y = afq_dataset.y
-    groups = afq_dataset.groups
-    feature_names = afq_dataset.feature_names
-    group_names = afq_dataset.group_names
-    subjects = afq_dataset.subjects
-
-    X = SimpleImputer(strategy="median").fit_transform(X)
+    X = SimpleImputer(strategy="median").fit_transform(afq_dataset.X)
 
     tract_data = (
         pd.DataFrame(columns=afq_dataset.feature_names, data=X)

--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -1,3 +1,5 @@
+"""Perform linear modeling at leach node along the tract."""
+
 import numpy as np
 import pandas as pd
 import statsmodels.formula.api as smf
@@ -17,6 +19,7 @@ def node_wise_regression(
     rand_eff="subjectID",
 ):
     """Model group differences using node-wise regression along the length of the tract.
+
        Returns a list of beta-weights, confidence intervals, p-values, and rejection criteria
        based on multiple-comparison correction.
 
@@ -27,7 +30,6 @@ def node_wise_regression(
 
     afq_dataset: AFQDataset
         Loaded AFQDataset object
-
     tract: str
         String specifying the tract to model
 
@@ -51,7 +53,6 @@ def node_wise_regression(
 
     Returns
     -------
-
     tract_dict: dict
         A dictionary with the following key-value pairs:
 
@@ -95,7 +96,6 @@ def node_wise_regression(
             A list of the statsmodels object fit along the length of the nodes
 
     """
-
     X = SimpleImputer(strategy="median").fit_transform(afq_dataset.X)
     afq_dataset.target_cols[0] = group
 

--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -27,7 +27,6 @@ def node_wise_regression(
 
     Parameters
     ----------
-
     afq_dataset: AFQDataset
         Loaded AFQDataset object
     tract: str

--- a/afqinsight/parametric.py
+++ b/afqinsight/parametric.py
@@ -97,6 +97,7 @@ def node_wise_regression(
     """
 
     X = SimpleImputer(strategy="median").fit_transform(afq_dataset.X)
+    afqdata.target_cols[0] = group
 
     tract_data = (
         pd.DataFrame(columns=afq_dataset.feature_names, data=X)
@@ -140,14 +141,14 @@ def node_wise_regression(
             fits[column] = fit
 
         # pull out coefficients, CIs, and p-values from our model
-        coefs_default[ii] = fit.params.filter(regex="Intercept", axis=0)[0]
-        coefs_treat[ii] = fit.params.filter(regex=group, axis=0)[0]
+        coefs_default[ii] = fit.params.filter(regex="Intercept", axis=0).iloc[0]
+        coefs_treat[ii] = fit.params.filter(regex=group, axis=0).iloc[0]
 
         cis_default[ii] = (
             fit.conf_int(alpha=0.05).filter(regex="Intercept", axis=0).values
         )
         cis_treat[ii] = fit.conf_int(alpha=0.05).filter(regex=group, axis=0).values
-        pvals[ii] = fit.pvalues.filter(regex=group, axis=0)[0]
+        pvals[ii] = fit.pvalues.filter(regex=group, axis=0).iloc[0]
 
     # Correct p-values for multiple comparisons
     reject, pval_corrected, _, _ = multipletests(pvals, alpha=0.05, method="fdr_bh")

--- a/afqinsight/plot.py
+++ b/afqinsight/plot.py
@@ -334,11 +334,10 @@ def plot_tract_profiles(
 
 
 def plot_regression_profiles(model_dict, ax):
-    """Plot parametric tract profiles based on node-wise linear models
+    """Plot parametric tract profiles based on node-wise linear models.
 
     Parameters
     ----------
-
     model_dict: dict
         Dictionary returned by parametric.node_wise_regression containing information about
         parametric model fits over the length of a tract
@@ -348,12 +347,10 @@ def plot_regression_profiles(model_dict, ax):
 
     Returns
     -------
-
     ax: matplotlib.axes
         A matplotlib axes with plotted parametric tract profiles
 
     """
-
     # Add beta-weight for group to intercept (mean control)
     combo_coefs = model_dict["reference_coefs"] + model_dict["group_coefs"]
 

--- a/afqinsight/plot.py
+++ b/afqinsight/plot.py
@@ -332,51 +332,50 @@ def plot_tract_profiles(
 
     return figs
 
-def plot_regression_profiles(model_dict,ax):
-    
+
+def plot_regression_profiles(model_dict, ax):
     """Plot parametric tract profiles based on node-wise linear models
 
     Parameters
     ----------
-    
+
     model_dict: dict
         Dictionary returned by parametric.node_wise_regression containing information about
         parametric model fits over the length of a tract
-        
+
     ax: matplotlib.axes
         A matplotlib axes for a subplot where the tract profiles will be plotted
-    
 
     Returns
     -------
-    
-    ax: matplotlib.axes
-    	A matplotlib axes with plotted parametric tract profiles
-        
-    """
-    
-    ## Add beta-weight for group to intercept (mean control)
-    combo_coefs = model_dict['reference_coefs'] + model_dict['group_coefs']
-    
-    ## Generate 95% CI around group mean by adding to control intercept
-    combo_conf_int =  np.zeros(model_dict['reference_CI'].shape)
-    combo_conf_int[:,0] = model_dict['reference_coefs'] + model_dict['group_CI'][:,0]
-    combo_conf_int[:,1] = model_dict['reference_coefs'] + model_dict['group_CI'][:,1]
-    
-    ## Plot regression based tract profiles
-    ax.plot(model_dict['reference_coefs'])
-    ax.plot(combo_coefs)
-    ax.plot(model_dict['reject_idx'], np.zeros(len(model_dict['reject_idx'])), "k*")
 
-    ax.fill_between(range(100), 
-                  model_dict['reference_CI'][:,0],
-                  model_dict['reference_CI'][:,1], 
-                  alpha=0.5)  # Adding fill_between
-    
-    
-    ax.fill_between(range(100),
-                    combo_conf_int[:,0], 
-                    combo_conf_int[:,1], 
-                    alpha=0.5)  # Adding fill_between
-    
+    ax: matplotlib.axes
+        A matplotlib axes with plotted parametric tract profiles
+
+    """
+
+    # Add beta-weight for group to intercept (mean control)
+    combo_coefs = model_dict["reference_coefs"] + model_dict["group_coefs"]
+
+    # Generate 95% CI around group mean by adding to control intercept
+    combo_conf_int = np.zeros(model_dict["reference_CI"].shape)
+    combo_conf_int[:, 0] = model_dict["reference_coefs"] + model_dict["group_CI"][:, 0]
+    combo_conf_int[:, 1] = model_dict["reference_coefs"] + model_dict["group_CI"][:, 1]
+
+    # Plot regression based tract profiles
+    ax.plot(model_dict["reference_coefs"])
+    ax.plot(combo_coefs)
+    ax.plot(model_dict["reject_idx"], np.zeros(len(model_dict["reject_idx"])), "k*")
+
+    ax.fill_between(
+        range(100),
+        model_dict["reference_CI"][:, 0],
+        model_dict["reference_CI"][:, 1],
+        alpha=0.5,
+    )  # Adding fill_between
+
+    ax.fill_between(
+        range(100), combo_conf_int[:, 0], combo_conf_int[:, 1], alpha=0.5
+    )  # Adding fill_between
+
     return ax

--- a/afqinsight/plot.py
+++ b/afqinsight/plot.py
@@ -331,3 +331,52 @@ def plot_tract_profiles(
         figs[metric] = fig
 
     return figs
+
+def plot_regression_profiles(model_dict,ax):
+    
+    """Plot parametric tract profiles based on node-wise linear models
+
+    Parameters
+    ----------
+    
+    model_dict: dict
+        Dictionary returned by parametric.node_wise_regression containing information about
+        parametric model fits over the length of a tract
+        
+    ax: matplotlib.axes
+        A matplotlib axes for a subplot where the tract profiles will be plotted
+    
+
+    Returns
+    -------
+    
+    ax: matplotlib.axes
+    	A matplotlib axes with plotted parametric tract profiles
+        
+    """
+    
+    ## Add beta-weight for group to intercept (mean control)
+    combo_coefs = model_dict['reference_coefs'] + model_dict['group_coefs']
+    
+    ## Generate 95% CI around group mean by adding to control intercept
+    combo_conf_int =  np.zeros(model_dict['reference_CI'].shape)
+    combo_conf_int[:,0] = model_dict['reference_coefs'] + model_dict['group_CI'][:,0]
+    combo_conf_int[:,1] = model_dict['reference_coefs'] + model_dict['group_CI'][:,1]
+    
+    ## Plot regression based tract profiles
+    ax.plot(model_dict['reference_coefs'])
+    ax.plot(combo_coefs)
+    ax.plot(model_dict['reject_idx'], np.zeros(len(model_dict['reject_idx'])), "k*")
+
+    ax.fill_between(range(100), 
+                  model_dict['reference_CI'][:,0],
+                  model_dict['reference_CI'][:,1], 
+                  alpha=0.5)  # Adding fill_between
+    
+    
+    ax.fill_between(range(100),
+                    combo_conf_int[:,0], 
+                    combo_conf_int[:,1], 
+                    alpha=0.5)  # Adding fill_between
+    
+    return ax

--- a/examples/plot_als_comparison.py
+++ b/examples/plot_als_comparison.py
@@ -21,17 +21,10 @@ tract (the left corticospinal tract) and in one feature (FA).
 """
 
 import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
 
 from afqinsight import AFQDataset
 from afqinsight.parametric import node_wise_regression
 from afqinsight.plot import plot_regression_profiles
-from statsmodels.api import OLS
-from statsmodels.stats.anova import anova_lm
-from statsmodels.stats.multitest import multipletests
-
-from sklearn.impute import SimpleImputer
 
 #############################################################################
 # Fetch data from Sarica et al.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >=3.10
 install_requires =
     dipy>=1.0.0
     groupyr>=0.3.3
-    matplotlib
+    matplotlib<3.9
     numpy==1.23.5
     pandas==2.1.4
     requests
@@ -49,7 +49,7 @@ include_package_data = True
 packages = find:
 
 [options.extras_require]
-tables = 
+tables =
     tables==3.9.1
 torch =
     torch


### PR DESCRIPTION
Added a new module `parametric.py` that performs OLS and LME modeling over the nodes of a given tract to allow for group comparisons, while controlling for potential covariates. Additionally, added another plotting function to `plot.py` that allows the user to visualize the "tract profiles" generated by the linear models and updated the `plot_als_comparison.py` example to demonstrate how to use these functions.